### PR TITLE
Fix tooltip position

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WWidget.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WWidget.java
@@ -139,7 +139,7 @@ public class WWidget {
 	@Environment(EnvType.CLIENT)
 	public void paintForeground(int x, int y, int mouseX, int mouseY) {
 		if (mouseX >= x && mouseX < x+getWidth() && mouseY >= y && mouseY < y+getHeight()) {
-			renderTooltip(mouseX-x+getX(),mouseY-y+getY() );
+			renderTooltip(mouseX, mouseY);
 		}
 	}
 


### PR DESCRIPTION
Changes proposed in this pull request:
  - Fix the `WWidget.renderForeground` tooltip position

![screenshot](https://cdn.discordapp.com/attachments/598330394118586403/604982976861962272/unknown.png)