### PR TITLE
Add setters for min and max in WAbstractSlider

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
@@ -30,7 +30,7 @@ public abstract class WAbstractSlider extends WWidget {
 	 */
 	private static final int DRAGGING_FINISHED_RATE_LIMIT_FOR_SCROLLING = 10;
 
-	protected final int min, max;
+	protected int min, max;
 	protected final Axis axis;
 
 	protected int value;
@@ -216,6 +216,14 @@ public abstract class WAbstractSlider extends WWidget {
 
 	public int getMaxValue() {
 		return max;
+	}
+
+	public void setMinValue(int min) {
+		this.min = min;
+	}
+
+	public void setMaxValue(int max) {
+		this.max = max;
 	}
 
 	public Axis getAxis() {


### PR DESCRIPTION
Fixed from Old PR.
I have no idea why it started changing it, but anyway here's the fixed one.