### PR TITLE
1.16 breaking changes

### DIFF
--- a/GuiTest/build.gradle
+++ b/GuiTest/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-	id 'fabric-loom' version '0.2.5-SNAPSHOT'
+	id 'fabric-loom' version '0.2.7-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/GuiTest/gradle.properties
+++ b/GuiTest/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.15.2
-	yarn_mappings=1.15.2+build.2
-	loader_version=0.7.5+build.178
+	minecraft_version=20w17a
+	yarn_mappings=20w17a+build.4
+	loader_version=0.8.2+build.194
 
 # Mod Properties
-	mod_version = 1.5.1
+	mod_version = 1.9.0
 	maven_group = io.github.cottonmc
 	archives_base_name = LibGui
 
 # Dependencies
-	fabric_version=0.4.29+build.290-1.15
+	fabric_version=0.6.2+build.327-1.16
 	jankson_version=2.0.1+j1.2.0

--- a/GuiTest/src/main/java/io/github/cottonmc/test/GuiBlockEntity.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/GuiBlockEntity.java
@@ -3,7 +3,7 @@ package io.github.cottonmc.test;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.DefaultedList;
+import net.minecraft.util.collection.DefaultedList;
 
 public class GuiBlockEntity extends BlockEntity implements ImplementedInventory {
 	
@@ -19,7 +19,7 @@ public class GuiBlockEntity extends BlockEntity implements ImplementedInventory 
 	}
 	
 	@Override
-	public boolean canPlayerUseInv(PlayerEntity player) {
+	public boolean canPlayerUse(PlayerEntity player) {
 		return pos.isWithinDistance(player.getBlockPos(), 4.5);
 	}
 

--- a/GuiTest/src/main/java/io/github/cottonmc/test/ImplementedInventory.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/ImplementedInventory.java
@@ -6,7 +6,7 @@ import net.minecraft.inventory.Inventory;
 import net.minecraft.inventory.SidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.util.DefaultedList;
+import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.Direction;
 
 import java.util.List;
@@ -64,7 +64,7 @@ public interface ImplementedInventory extends SidedInventory {
      * @return the available slots
      */
     @Override
-    default int[] getInvAvailableSlots(Direction side) {
+    default int[] getAvailableSlots(Direction side) {
         int[] result = new int[getItems().size()];
         for (int i = 0; i < result.length; i++) {
             result[i] = i;
@@ -84,7 +84,7 @@ public interface ImplementedInventory extends SidedInventory {
      * @return true if the stack can be inserted
      */
     @Override
-    default boolean canInsertInvStack(int slot, ItemStack stack, Direction side) {
+    default boolean canInsert(int slot, ItemStack stack, Direction side) {
         return true;
     }
 
@@ -99,7 +99,7 @@ public interface ImplementedInventory extends SidedInventory {
      * @return true if the stack can be extracted
      */
     @Override
-    default boolean canExtractInvStack(int slot, ItemStack stack, Direction side) {
+    default boolean canExtract(int slot, ItemStack stack, Direction side) {
         return true;
     }
 
@@ -113,7 +113,7 @@ public interface ImplementedInventory extends SidedInventory {
      * @return the inventory size
      */
     @Override
-    default int getInvSize() {
+    default int size() {
         return getItems().size();
     }
 
@@ -121,9 +121,9 @@ public interface ImplementedInventory extends SidedInventory {
      * @return true if this inventory has only empty stacks, false otherwise
      */
     @Override
-    default boolean isInvEmpty() {
-        for (int i = 0; i < getInvSize(); i++) {
-            ItemStack stack = getInvStack(i);
+    default boolean isEmpty() {
+        for (int i = 0; i < size(); i++) {
+            ItemStack stack = getStack(i);
             if (!stack.isEmpty()) {
                 return false;
             }
@@ -139,7 +139,7 @@ public interface ImplementedInventory extends SidedInventory {
      * @return the item in the slot
      */
     @Override
-    default ItemStack getInvStack(int slot) {
+    default ItemStack getStack(int slot) {
         return getItems().get(slot);
     }
 
@@ -154,7 +154,7 @@ public interface ImplementedInventory extends SidedInventory {
      * @return a stack
      */
     @Override
-    default ItemStack takeInvStack(int slot, int count) {
+    default ItemStack removeStack(int slot, int count) {
         ItemStack result = Inventories.splitStack(getItems(), slot, count);
         if (!result.isEmpty()) {
             markDirty();
@@ -172,24 +172,24 @@ public interface ImplementedInventory extends SidedInventory {
      * @return the removed stack
      */
     @Override
-    default ItemStack removeInvStack(int slot) {
+    default ItemStack removeStack(int slot) {
         return Inventories.removeStack(getItems(), slot);
     }
 
     /**
      * Replaces the current stack in the {@code slot} with the provided stack.
      *
-     * <p>If the stack is too big for this inventory ({@link Inventory#getInvMaxStackAmount()}),
+     * <p>If the stack is too big for this inventory ({@link Inventory#getMaxCountPerStack()} ()}),
      * it gets resized to this inventory's maximum amount.
      *
      * @param slot the slot
      * @param stack the stack
      */
     @Override
-    default void setInvStack(int slot, ItemStack stack) {
+    default void setStack(int slot, ItemStack stack) {
         getItems().set(slot, stack);
-        if (stack.getCount() > getInvMaxStackAmount()) {
-            stack.setCount(getInvMaxStackAmount());
+        if (stack.getCount() > getMaxCountPerStack()) {
+            stack.setCount(getMaxCountPerStack());
         }
     }
 
@@ -207,7 +207,7 @@ public interface ImplementedInventory extends SidedInventory {
     }
 
     @Override
-    default boolean canPlayerUseInv(PlayerEntity player) {
+    default boolean canPlayerUse(PlayerEntity player) {
         return true;
     }
 }

--- a/GuiTest/src/main/java/io/github/cottonmc/test/LibGuiTest.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/LibGuiTest.java
@@ -10,13 +10,13 @@ import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.container.BlockContext;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.screen.ScreenHandlerContext;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.PacketByteBuf;
 import net.minecraft.util.registry.Registry;
 
 public class LibGuiTest implements ModInitializer {
@@ -38,7 +38,7 @@ public class LibGuiTest implements ModInitializer {
 		
 		
 		ContainerProviderRegistry.INSTANCE.registerFactory(new Identifier(MODID, "gui"), (int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf)->{
-			return new TestContainer(syncId, player.inventory, BlockContext.create(player.getEntityWorld(), buf.readBlockPos()));
+			return new TestController(syncId, player.inventory, ScreenHandlerContext.create(player.getEntityWorld(), buf.readBlockPos()));
 		});
 		
 		Optional<ModContainer> containerOpt = FabricLoader.getInstance().getModContainer("jankson");

--- a/GuiTest/src/main/java/io/github/cottonmc/test/TestController.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/TestController.java
@@ -1,18 +1,18 @@
 package io.github.cottonmc.test;
 
-import io.github.cottonmc.cotton.gui.CottonCraftingController;
+import io.github.cottonmc.cotton.gui.CottonInventoryController;
 import io.github.cottonmc.cotton.gui.widget.WButton;
 import io.github.cottonmc.cotton.gui.widget.WGridPanel;
 import io.github.cottonmc.cotton.gui.widget.WItemSlot;
 import io.github.cottonmc.cotton.gui.widget.WPlayerInvPanel;
-import net.minecraft.container.BlockContext;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.ScreenHandlerContext;
 import net.minecraft.text.LiteralText;
 
-public class TestContainer extends CottonCraftingController {
+public class TestController extends CottonInventoryController {
 	
-	public TestContainer(int syncId, PlayerInventory playerInventory, BlockContext context) {
-		super(null, syncId, playerInventory, getBlockInventory(context), null);
+	public TestController(int syncId, PlayerInventory playerInventory, ScreenHandlerContext context) {
+		super(syncId, playerInventory, getBlockInventory(context), null);
 		
 		WGridPanel root = (WGridPanel)this.getRootPanel();
 		

--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/LibGuiTestClient.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/LibGuiTestClient.java
@@ -2,17 +2,17 @@ package io.github.cottonmc.test.client;
 
 import io.github.cottonmc.cotton.gui.client.CottonInventoryScreen;
 import io.github.cottonmc.test.LibGuiTest;
-import io.github.cottonmc.test.TestContainer;
+import io.github.cottonmc.test.TestController;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
-import net.minecraft.container.BlockContext;
+import net.minecraft.screen.ScreenHandlerContext;
 import net.minecraft.util.Identifier;
 
 public class LibGuiTestClient implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
-		ScreenProviderRegistry.INSTANCE.registerFactory(new Identifier(LibGuiTest.MODID, "gui"), (syncId, identifier, player, buf)->new CottonInventoryScreen<TestContainer>(new TestContainer(syncId, player.inventory, BlockContext.create(player.getEntityWorld(), buf.readBlockPos())), player));
+		ScreenProviderRegistry.INSTANCE.registerFactory(new Identifier(LibGuiTest.MODID, "gui"), (syncId, identifier, player, buf)->new CottonInventoryScreen<TestController>(new TestController(syncId, player.inventory, ScreenHandlerContext.create(player.getEntityWorld(), buf.readBlockPos())), player));
 	}
 
 }

--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
@@ -20,7 +20,9 @@ import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import io.github.cottonmc.cotton.gui.widget.data.Color;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 public class TestClientGui extends LightweightGuiDescription {
@@ -43,8 +45,8 @@ public class TestClientGui extends LightweightGuiDescription {
 		
 		WLabel title = new WLabel(new LiteralText("Client Test Gui"), WLabel.DEFAULT_TEXT_COLOR) {
 			@Override
-			public void addInformation(List<String> information) {
-				information.add("Radical!");
+			public void addTooltip(List<Text> tooltip) {
+				tooltip.add(new LiteralText("Radical!"));
 			}
 		};
 		root.add(title, 0, 0);
@@ -142,9 +144,7 @@ public class TestClientGui extends LightweightGuiDescription {
 		}
 		
 		@Override
-		public void paintBackground(int x, int y, int mouseX, int mouseY) {
-			super.paintBackground(x, y, mouseX, mouseY);
-			
+		public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 			ScreenDrawing.coloredRect(x, y, this.getWidth(), this.getHeight(), color);
 		}
 	}

--- a/src/main/java/io/github/cottonmc/cotton/gui/CottonInventoryController.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/CottonInventoryController.java
@@ -374,7 +374,7 @@ public class CottonInventoryController extends ScreenHandler implements GuiDescr
 	//extends ScreenHandler {
 		@Override
 		public boolean canUse(PlayerEntity entity) {
-			return (blockInventory!=null) ? blockInventory.canPlayerUseInv(entity) : true;
+			return (blockInventory!=null) ? blockInventory.canPlayerUse(entity) : true;
 		}
 	//}
 

--- a/src/main/java/io/github/cottonmc/cotton/gui/CottonInventoryController.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/CottonInventoryController.java
@@ -17,20 +17,15 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.Recipe;
-import net.minecraft.recipe.RecipeFinder;
-import net.minecraft.recipe.RecipeInputProvider;
-import net.minecraft.recipe.RecipeType;
 import net.minecraft.screen.*;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.world.World;
 
-public class CottonCraftingController extends AbstractRecipeScreenHandler<Inventory> implements GuiDescription {
+public class CottonInventoryController extends ScreenHandler implements GuiDescription {
 	
 	protected Inventory blockInventory;
 	protected PlayerInventory playerInventory;
-	protected RecipeType<?> recipeType;
 	protected World world;
 	protected PropertyDelegate propertyDelegate;
 	
@@ -40,20 +35,18 @@ public class CottonCraftingController extends AbstractRecipeScreenHandler<Invent
 	
 	protected WWidget focus;
 	
-	public CottonCraftingController(RecipeType<?> recipeType, int syncId, PlayerInventory playerInventory) {
+	public CottonInventoryController(int syncId, PlayerInventory playerInventory) {
 		super(null, syncId);
 		this.blockInventory = null;
 		this.playerInventory = playerInventory;
-		this.recipeType = recipeType;
 		this.world = playerInventory.player.world;
 		this.propertyDelegate = null;//new ArrayPropertyDelegate(1);
 	}
 	
-	public CottonCraftingController(RecipeType<?> recipeType, int syncId, PlayerInventory playerInventory, Inventory blockInventory, PropertyDelegate propertyDelegate) {
+	public CottonInventoryController(int syncId, PlayerInventory playerInventory, Inventory blockInventory, PropertyDelegate propertyDelegate) {
 		super(null, syncId);
 		this.blockInventory = blockInventory;
 		this.playerInventory = playerInventory;
-		this.recipeType = recipeType;
 		this.world = playerInventory.player.world;
 		this.propertyDelegate = propertyDelegate;
 		if (propertyDelegate!=null && propertyDelegate.size()>0) this.addProperties(propertyDelegate);
@@ -67,12 +60,12 @@ public class CottonCraftingController extends AbstractRecipeScreenHandler<Invent
 		return LibGuiClient.config.darkMode ? darkTitleColor : titleColor;
 	}
 	
-	public CottonCraftingController setRootPanel(WPanel panel) {
+	public CottonInventoryController setRootPanel(WPanel panel) {
 		this.rootPanel = panel;
 		return this;
 	}
 	
-	public CottonCraftingController setTitleColor(int color) {
+	public CottonInventoryController setTitleColor(int color) {
 		this.titleColor = color;
 		return this;
 	}
@@ -372,52 +365,11 @@ public class CottonCraftingController extends AbstractRecipeScreenHandler<Invent
 		}).orElse(new ArrayPropertyDelegate(0));
 	}
 	
-	//extends CraftingContainer<Inventory> {
+	//extends ScreenHandler {
 		@Override
-		public void populateRecipeFinder(RecipeFinder recipeFinder) {
-			if (this.blockInventory instanceof RecipeInputProvider) {
-				((RecipeInputProvider)this.blockInventory).provideRecipeInputs(recipeFinder);
-			}
+		public boolean canUse(PlayerEntity entity) {
+			return (blockInventory!=null) ? blockInventory.canPlayerUseInv(entity) : true;
 		}
-		
-		@Override
-		public void clearCraftingSlots() {
-			if (this.blockInventory!=null) this.blockInventory.clear();
-		}
-		
-		@Override
-		public boolean matches(Recipe<? super Inventory> recipe) {
-			if (blockInventory==null || world==null) return false;
-			return false; //TODO recipe support
-		}
-		
-		@Override
-		public int getCraftingResultSlotIndex() {
-			return -1;
-		}
-
-		@Override
-		public int getCraftingWidth() {
-			return 1;
-		}
-
-		@Override
-		public int getCraftingHeight() {
-			return 1;
-		}
-
-		@Override
-		@Environment(EnvType.CLIENT)
-		public int getCraftingSlotCount() {
-			return 1;
-		}
-		
-		//(implied) extends Container {
-			@Override
-			public boolean canUse(PlayerEntity entity) {
-				return (blockInventory!=null) ? blockInventory.canPlayerUseInv(entity) : true;
-			}
-		//}
 	//}
 
 	@Override

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/CottonClientScreen.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/CottonClientScreen.java
@@ -55,36 +55,33 @@ public class CottonClientScreen extends Screen implements TextHoverRendererScree
 		}
 	}
 	
-	public void paint(int mouseX, int mouseY) {
-		super.renderBackground(ScreenDrawing.matrices);
+	public void paint(MatrixStack matrices, int mouseX, int mouseY) {
+		super.renderBackground(matrices);
 		
 		if (description!=null) {
 			WPanel root = description.getRootPanel();
 			if (root!=null) {
-				root.paintBackground(left, top, mouseX-left, mouseY-top);
+				root.paint(matrices, left, top, mouseX-left, mouseY-top);
 			}
 		}
 		
 		if (getTitle() != null) {
-			textRenderer.method_27528(ScreenDrawing.matrices, getTitle(), left, top, description.getTitleColor());
+			textRenderer.method_27528(matrices, getTitle(), left, top, description.getTitleColor());
 		}
 	}
 	
 	@SuppressWarnings("deprecation")
 	@Override
 	public void render(MatrixStack matrices, int mouseX, int mouseY, float partialTicks) {
-		ScreenDrawing.matrices = matrices;
-		paint(mouseX, mouseY);
+		paint(matrices, mouseX, mouseY);
 		
 		super.render(matrices, mouseX, mouseY, partialTicks);
 		
 		if (description!=null) {
 			WPanel root = description.getRootPanel();
 			if (root!=null) {
-				root.paintForeground(left, top, mouseX, mouseY);
-				
 				WWidget hitChild = root.hit(mouseX-left, mouseY-top);
-				if (hitChild!=null) hitChild.renderTooltip(left, top, mouseX-left, mouseY-top);
+				if (hitChild!=null) hitChild.renderTooltip(matrices, left, top, mouseX-left, mouseY-top);
 			}
 		}
 	}
@@ -223,7 +220,7 @@ public class CottonClientScreen extends Screen implements TextHoverRendererScree
 	//}
 
 	@Override
-	public void renderTextHover(Text text, int x, int y) {
-		renderTextHoverEffect(ScreenDrawing.matrices, text, x, y);
+	public void renderTextHover(MatrixStack matrices, Text text, int x, int y) {
+		renderTextHoverEffect(matrices, text, x, y);
 	}
 }

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/CottonHud.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/CottonHud.java
@@ -106,7 +106,6 @@ public enum CottonHud implements HudRenderCallback {
 
 	@Override
 	public void onHudRender(MatrixStack matrices, float tickDelta) {
-		ScreenDrawing.matrices = matrices;
 		Window window = MinecraftClient.getInstance().getWindow();
 		int hudWidth = window.getScaledWidth();
 		int hudHeight = window.getScaledHeight();
@@ -116,7 +115,7 @@ public enum CottonHud implements HudRenderCallback {
 				positioner.reposition(widget, hudWidth, hudHeight);
 			}
 
-			widget.paintBackground(widget.getX(), widget.getY(), -1, -1);
+			widget.paint(matrices, widget.getX(), widget.getY(), -1, -1);
 		}
 	}
 

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/CottonInventoryScreen.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/CottonInventoryScreen.java
@@ -4,7 +4,7 @@ import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.render.DiffuseLighting;
 import org.lwjgl.glfw.GLFW;
 
-import io.github.cottonmc.cotton.gui.CottonCraftingController;
+import io.github.cottonmc.cotton.gui.CottonInventoryController;
 import io.github.cottonmc.cotton.gui.widget.WPanel;
 import io.github.cottonmc.cotton.gui.widget.WWidget;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/CottonInventoryScreen.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/CottonInventoryScreen.java
@@ -1,11 +1,11 @@
 package io.github.cottonmc.cotton.gui.client;
 
+import io.github.cottonmc.cotton.gui.CottonInventoryController;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.render.DiffuseLighting;
 import net.minecraft.client.util.math.MatrixStack;
 import org.lwjgl.glfw.GLFW;
 
-import io.github.cottonmc.cotton.gui.CottonInventoryController;
 import io.github.cottonmc.cotton.gui.widget.WPanel;
 import io.github.cottonmc.cotton.gui.widget.WWidget;
 import net.minecraft.client.MinecraftClient;
@@ -13,8 +13,8 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 
-public class CottonInventoryScreen<T extends CottonCraftingController> extends HandledScreen<T> implements TextHoverRendererScreen {
-	protected CottonCraftingController description;
+public class CottonInventoryScreen<T extends CottonInventoryController> extends HandledScreen<T> implements TextHoverRendererScreen {
+	protected CottonInventoryController description;
 	public static final int PADDING = 8;
 	protected WWidget lastResponder = null;
 	protected WWidget focus = null;
@@ -187,26 +187,25 @@ public class CottonInventoryScreen<T extends CottonCraftingController> extends H
 	@Override
 	protected void drawBackground(MatrixStack matrices, float partialTicks, int mouseX, int mouseY) {} //This is just an AbstractContainerScreen thing; most Screens don't work this way.
 	
-	public void paint(int mouseX, int mouseY) {
-		super.renderBackground(ScreenDrawing.matrices);
+	public void paint(MatrixStack matrices, int mouseX, int mouseY) {
+		super.renderBackground(matrices);
 		
 		if (description!=null) {
 			WPanel root = description.getRootPanel();
 			if (root!=null) {
-				root.paintBackground(x, y, mouseX-x, mouseY-y);
+				root.paint(matrices, x, y, mouseX-x, mouseY-y);
 			}
 		}
 		
 		if (getTitle() != null) {
-			textRenderer.method_27528(ScreenDrawing.matrices, getTitle(), x, y, description.getTitleColor());
+			textRenderer.method_27528(matrices, getTitle(), x, y, description.getTitleColor());
 		}
 	}
 	
 	@SuppressWarnings("deprecation")
 	@Override
 	public void render(MatrixStack matrices, int mouseX, int mouseY, float partialTicks) {
-		ScreenDrawing.matrices = matrices;
-		paint(mouseX, mouseY);
+		paint(matrices, mouseX, mouseY);
 		
 		super.render(matrices, mouseX, mouseY, partialTicks);
 		DiffuseLighting.disable(); //Needed because super.render leaves dirty state
@@ -214,10 +213,8 @@ public class CottonInventoryScreen<T extends CottonCraftingController> extends H
 		if (description!=null) {
 			WPanel root = description.getRootPanel();
 			if (root!=null) {
-				root.paintForeground(x, y, mouseX, mouseY);
-				
 				WWidget hitChild = root.hit(mouseX-x, mouseY-y);
-				if (hitChild!=null) hitChild.renderTooltip(x, y, mouseX-x, mouseY-y);
+				if (hitChild!=null) hitChild.renderTooltip(matrices, x, y, mouseX-x, mouseY-y);
 			}
 		}
 		
@@ -236,7 +233,7 @@ public class CottonInventoryScreen<T extends CottonCraftingController> extends H
 	}
 
 	@Override
-	public void renderTextHover(Text text, int x, int y) {
-		renderTextHoverEffect(ScreenDrawing.matrices, text, x, y);
+	public void renderTextHover(MatrixStack matrices, Text text, int x, int y) {
+		renderTextHoverEffect(matrices, text, x, y);
 	}
 }

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/ScreenDrawing.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/ScreenDrawing.java
@@ -9,7 +9,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 
 import io.github.cottonmc.cotton.gui.widget.data.Alignment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexFormats;
@@ -65,12 +64,11 @@ public class ScreenDrawing {
 		RenderSystem.enableBlend();
 		//GlStateManager.disableTexture2D();
 		RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO);
-		RenderSystem.color4f(r, g, b, 1.0f);
-		buffer.begin(GL11.GL_QUADS, VertexFormats.POSITION_TEXTURE); //I thought GL_QUADS was deprecated but okay, sure.
-		buffer.vertex(x,         y + height, 0).texture(u1, v2).next();
-		buffer.vertex(x + width, y + height, 0).texture(u2, v2).next();
-		buffer.vertex(x + width, y,          0).texture(u2, v1).next();
-		buffer.vertex(x,         y,          0).texture(u1, v1).next();
+		buffer.begin(GL11.GL_QUADS, VertexFormats.POSITION_COLOR_TEXTURE); //I thought GL_QUADS was deprecated but okay, sure.
+		buffer.vertex(x,         y + height, 0).color(r, g, b, 1.0f).texture(u1, v2).next();
+		buffer.vertex(x + width, y + height, 0).color(r, g, b, 1.0f).texture(u2, v2).next();
+		buffer.vertex(x + width, y,          0).color(r, g, b, 1.0f).texture(u2, v1).next();
+		buffer.vertex(x,         y,          0).color(r, g, b, 1.0f).texture(u1, v1).next();
 		tessellator.draw();
 		//GlStateManager.enableTexture2D();
 		RenderSystem.disableBlend();
@@ -126,12 +124,11 @@ public class ScreenDrawing {
 		RenderSystem.enableBlend();
 		RenderSystem.disableTexture();
 		RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO);
-		RenderSystem.color4f(r, g, b, a);
-		buffer.begin(GL11.GL_QUADS, VertexFormats.POSITION); //I thought GL_QUADS was deprecated but okay, sure.
-		buffer.vertex(left,         top + height, 0.0D).next();
-		buffer.vertex(left + width, top + height, 0.0D).next();
-		buffer.vertex(left + width, top,          0.0D).next();
-		buffer.vertex(left,         top,          0.0D).next();
+		buffer.begin(GL11.GL_QUADS, VertexFormats.POSITION_COLOR); //I thought GL_QUADS was deprecated but okay, sure.
+		buffer.vertex(left,         top + height, 0.0D).color(r, g, b, a).next();
+		buffer.vertex(left + width, top + height, 0.0D).color(r, g, b, a).next();
+		buffer.vertex(left + width, top,          0.0D).color(r, g, b, a).next();
+		buffer.vertex(left,         top,          0.0D).color(r, g, b, a).next();
 		tessellator.draw();
 		RenderSystem.enableTexture();
 		RenderSystem.disableBlend();

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/ScreenDrawing.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/ScreenDrawing.java
@@ -19,21 +19,7 @@ import net.minecraft.util.Identifier;
  * {@code ScreenDrawing} contains utility methods for drawing contents on a screen.
  */
 public class ScreenDrawing {
-	// Internal MatrixStack for rendering strings.
-	// TODO (2.0): Remove
-	static MatrixStack matrices;
-
 	private ScreenDrawing() {}
-
-	/**
-	 * Gets the currently bound matrix stack.
-	 *
-	 * @return the matrix stack
-	 * @since 1.9.0
-	 */
-	public static MatrixStack getMatrices() {
-		return matrices;
-	}
 
 	/**
 	 * Draws a textured rectangle.
@@ -301,14 +287,15 @@ public class ScreenDrawing {
 	/**
 	 * Draws a string with a custom alignment.
 	 *
-	 * @param s     the string
-	 * @param align the alignment of the string
-	 * @param x     the X position
-	 * @param y     the Y position
-	 * @param width the width of the string, used for aligning
-	 * @param color the text color
+	 * @param matrices the rendering matrix stack
+	 * @param s        the string
+	 * @param align    the alignment of the string
+	 * @param x        the X position
+	 * @param y        the Y position
+	 * @param width    the width of the string, used for aligning
+	 * @param color    the text color
 	 */
-	public static void drawString(String s, Alignment align, int x, int y, int width, int color) {
+	public static void drawString(MatrixStack matrices, String s, Alignment align, int x, int y, int width, int color) {
 		switch(align) {
 		case LEFT: {
 				MinecraftClient.getInstance().textRenderer.draw(matrices, s, x, y, color);
@@ -332,15 +319,16 @@ public class ScreenDrawing {
 	/**
 	 * Draws a text component with a custom alignment.
 	 *
-	 * @param text  the text
-	 * @param align the alignment of the string
-	 * @param x     the X position
-	 * @param y     the Y position
-	 * @param width the width of the string, used for aligning
-	 * @param color the text color
+	 * @param matrices the rendering matrix stack
+	 * @param text     the text
+	 * @param align    the alignment of the string
+	 * @param x        the X position
+	 * @param y        the Y position
+	 * @param width    the width of the string, used for aligning
+	 * @param color    the text color
 	 * @since 1.9.0
 	 */
-	public static void drawString(Text text, Alignment align, int x, int y, int width, int color) {
+	public static void drawString(MatrixStack matrices, Text text, Alignment align, int x, int y, int width, int color) {
 		switch(align) {
 		case LEFT: {
 				MinecraftClient.getInstance().textRenderer.method_27528(matrices, text, x, y, color);
@@ -364,14 +352,15 @@ public class ScreenDrawing {
 	/**
 	 * Draws a shadowed string.
 	 *
-	 * @param s     the string
-	 * @param align the alignment of the string
-	 * @param x     the X position
-	 * @param y     the Y position
-	 * @param width the width of the string, used for aligning
-	 * @param color the text color
+	 * @param matrices the rendering matrix stack
+	 * @param s        the string
+	 * @param align    the alignment of the string
+	 * @param x        the X position
+	 * @param y        the Y position
+	 * @param width    the width of the string, used for aligning
+	 * @param color    the text color
 	 */
-	public static void drawStringWithShadow(String s, Alignment align, int x, int y, int width, int color) {
+	public static void drawStringWithShadow(MatrixStack matrices, String s, Alignment align, int x, int y, int width, int color) {
 		switch(align) {
 		case LEFT: {
 				MinecraftClient.getInstance().textRenderer.drawWithShadow(matrices, s, x, y, color);
@@ -395,14 +384,15 @@ public class ScreenDrawing {
 	/**
 	 * Draws a shadowed text component.
 	 *
-	 * @param text  the text component
-	 * @param align the alignment of the string
-	 * @param x     the X position
-	 * @param y     the Y position
-	 * @param width the width of the string, used for aligning
-	 * @param color the text color
+	 * @param matrices the rendering matrix stack
+	 * @param text     the text component
+	 * @param align    the alignment of the string
+	 * @param x        the X position
+	 * @param y        the Y position
+	 * @param width    the width of the string, used for aligning
+	 * @param color    the text color
 	 */
-	public static void drawStringWithShadow(Text text, Alignment align, int x, int y, int width, int color) {
+	public static void drawStringWithShadow(MatrixStack matrices, Text text, Alignment align, int x, int y, int width, int color) {
 		switch(align) {
 		case LEFT: {
 				MinecraftClient.getInstance().textRenderer.method_27528(matrices, text, x, y, color);
@@ -426,34 +416,27 @@ public class ScreenDrawing {
 	/**
 	 * Draws a left-aligned string.
 	 *
-	 * @param s     the string
-	 * @param x     the X position
-	 * @param y     the Y position
-	 * @param color the text color
+	 * @param matrices the rendering matrix stack
+	 * @param s        the string
+	 * @param x        the X position
+	 * @param y        the Y position
+	 * @param color    the text color
 	 */
-	public static void drawString(String s, int x, int y, int color) {
+	public static void drawString(MatrixStack matrices, String s, int x, int y, int color) {
 		MinecraftClient.getInstance().textRenderer.draw(matrices, s, x, y, color);
 	}
 
 	/**
 	 * Draws a left-aligned text component.
 	 *
-	 * @param text  the text component
-	 * @param x     the X position
-	 * @param y     the Y position
-	 * @param color the text color
+	 * @param matrices the rendering matrix stack
+	 * @param text     the text component
+	 * @param x        the X position
+	 * @param y        the Y position
+	 * @param color    the text color
 	 */
-	public static void drawString(Text text, int x, int y, int color) {
+	public static void drawString(MatrixStack matrices, Text text, int x, int y, int color) {
 		MinecraftClient.getInstance().textRenderer.method_27528(matrices, text, x, y, color);
-	}
-
-	/**
-	 * @deprecated for removal; please use {@link #drawStringWithShadow(String, Alignment, int, int, int, int)}
-	 */
-	@Deprecated
-	public static void drawCenteredWithShadow(String s, int x, int y, int color) {
-		TextRenderer render = MinecraftClient.getInstance().textRenderer;
-		render.drawWithShadow(matrices, s, (float)(x - render.getStringWidth(s) / 2), (float)y, color);
 	}
 
 	public static int colorAtOpacity(int opaque, float opacity) {

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/TextHoverRendererScreen.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/TextHoverRendererScreen.java
@@ -1,10 +1,11 @@
 package io.github.cottonmc.cotton.gui.client;
 
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
 
 /**
  * Implemented by LibGui screens to access {@code Screen.renderTextHoverEffect()}.
  */
 public interface TextHoverRendererScreen {
-	void renderTextHover(Text text, int x, int y);
+	void renderTextHover(MatrixStack matrices, Text text, int x, int y);
 }

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/modmenu/ModMenuSupport.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/modmenu/ModMenuSupport.java
@@ -1,11 +1,10 @@
 package io.github.cottonmc.cotton.gui.client.modmenu;
 
-import java.util.function.Function;
 
 import io.github.cottonmc.cotton.gui.client.CottonClientScreen;
 import io.github.cottonmc.cotton.gui.client.LibGuiClient;
+import io.github.prospector.modmenu.api.ConfigScreenFactory;
 import io.github.prospector.modmenu.api.ModMenuApi;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.TranslatableText;
 
 public class ModMenuSupport implements ModMenuApi {
@@ -16,7 +15,7 @@ public class ModMenuSupport implements ModMenuApi {
 	}
 	
 	@Override
-	public Function<Screen, ? extends Screen> getConfigScreenFactory() {
+	public ConfigScreenFactory<?> getModConfigScreenFactory() {
 		return screen -> new CottonClientScreen(new TranslatableText("options.libgui.libgui_settings"), new ConfigGui(screen)) {
 			public void onClose() {
 				this.client.openScreen(screen);

--- a/src/main/java/io/github/cottonmc/cotton/gui/client/modmenu/WKirbSprite.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/modmenu/WKirbSprite.java
@@ -7,6 +7,7 @@ import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import io.github.cottonmc.cotton.gui.widget.WWidget;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
 public class WKirbSprite extends WWidget {
@@ -52,7 +53,7 @@ public class WKirbSprite extends WWidget {
 	
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		long now = System.nanoTime() / 1_000_000L;
 		
 		

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
@@ -34,6 +34,7 @@ public abstract class WAbstractSlider extends WWidget {
 
 	protected int min, max;
 	protected final Axis axis;
+	protected Direction direction;
 
 	protected int value;
 
@@ -71,6 +72,7 @@ public abstract class WAbstractSlider extends WWidget {
 		this.max = max;
 		this.axis = axis;
 		this.value = min;
+		this.direction = (axis == Axis.HORIZONTAL) ? Direction.RIGHT : Direction.UP;
 	}
 
 	/**
@@ -132,7 +134,25 @@ public abstract class WAbstractSlider extends WWidget {
 	}
 
 	private void moveSlider(int x, int y) {
-		int pos = (axis == Axis.VERTICAL ? (height - y) : x) - getThumbWidth() / 2;
+		int axisPos;
+
+		switch (direction) {
+			case UP:
+				axisPos = height - y;
+				break;
+			case DOWN:
+				axisPos = y;
+				break;
+			case LEFT:
+				axisPos = x;
+				break;
+			case RIGHT:
+			default:
+				axisPos = width - x;
+				break;
+		}
+
+		int pos = axisPos - getThumbWidth() / 2;
 		int rawValue = min + Math.round(valueToCoordRatio * pos);
 		int previousValue = value;
 		value = MathHelper.clamp(rawValue, min, max);
@@ -246,6 +266,31 @@ public abstract class WAbstractSlider extends WWidget {
 		return axis;
 	}
 
+	/**
+	 * Gets the direction of this slider.
+	 *
+	 * @return the direction
+	 * @since 2.0.0
+	 */
+	public Direction getDirection() {
+		return direction;
+	}
+
+	/**
+	 * Sets the direction of this slider.
+	 *
+	 * @param direction the new direction
+	 * @throws IllegalArgumentException if the {@linkplain Direction#getAxis() direction axis} is not equal to {@link #axis}.
+	 * @since 2.0.0
+	 */
+	public void setDirection(Direction direction) {
+		if (direction.getAxis() != axis) {
+			throw new IllegalArgumentException("Incorrect axis: " + axis);
+		}
+
+		this.direction = direction;
+	}
+
 	protected void onValueChanged(int value) {
 		if (valueChangeListener != null) valueChangeListener.accept(value);
 	}
@@ -293,5 +338,22 @@ public abstract class WAbstractSlider extends WWidget {
 
 	private static boolean isIncreasingKey(int ch) {
 		return ch == GLFW.GLFW_KEY_RIGHT || ch == GLFW.GLFW_KEY_UP;
+	}
+
+	public enum Direction {
+		UP(Axis.VERTICAL),
+		DOWN(Axis.VERTICAL),
+		LEFT(Axis.HORIZONTAL),
+		RIGHT(Axis.HORIZONTAL);
+
+		private final Axis axis;
+
+		Direction(Axis axis) {
+			this.axis = axis;
+		}
+
+		public Axis getAxis() {
+			return axis;
+		}
 	}
 }

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
@@ -144,11 +144,11 @@ public abstract class WAbstractSlider extends WWidget {
 				axisPos = y;
 				break;
 			case LEFT:
-				axisPos = x;
+				axisPos = width - x;
 				break;
 			case RIGHT:
 			default:
-				axisPos = width - x;
+				axisPos = x;
 				break;
 		}
 

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
@@ -170,8 +170,12 @@ public abstract class WAbstractSlider extends WWidget {
 	@Environment(EnvType.CLIENT)
 	@Override
 	public void onMouseScroll(int x, int y, double amount) {
+		if (direction == Direction.LEFT || direction == Direction.DOWN) {
+			amount = -amount;
+		}
+
 		int previous = value;
-		value = MathHelper.clamp(value + (int) (valueToCoordRatio * amount * 2), min, max);
+		value = MathHelper.clamp(value + (int) Math.signum(amount) * MathHelper.ceil(valueToCoordRatio * Math.abs(amount) * 2), min, max);
 
 		if (previous != value) {
 			onValueChanged(value);

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
@@ -336,28 +336,38 @@ public abstract class WAbstractSlider extends WWidget {
 		}
 	}
 
-	private static boolean isDecreasingKey(int ch) {
-		return ch == GLFW.GLFW_KEY_LEFT || ch == GLFW.GLFW_KEY_DOWN;
+	private boolean isDecreasingKey(int ch) {
+		return direction.isInverted()
+				? (ch == GLFW.GLFW_KEY_RIGHT || ch == GLFW.GLFW_KEY_UP)
+				: (ch == GLFW.GLFW_KEY_LEFT || ch == GLFW.GLFW_KEY_DOWN);
 	}
 
-	private static boolean isIncreasingKey(int ch) {
-		return ch == GLFW.GLFW_KEY_RIGHT || ch == GLFW.GLFW_KEY_UP;
+	private boolean isIncreasingKey(int ch) {
+		return direction.isInverted()
+				? (ch == GLFW.GLFW_KEY_LEFT || ch == GLFW.GLFW_KEY_DOWN)
+				: (ch == GLFW.GLFW_KEY_RIGHT || ch == GLFW.GLFW_KEY_UP);
 	}
 
 	public enum Direction {
-		UP(Axis.VERTICAL),
-		DOWN(Axis.VERTICAL),
-		LEFT(Axis.HORIZONTAL),
-		RIGHT(Axis.HORIZONTAL);
+		UP(Axis.VERTICAL, false),
+		DOWN(Axis.VERTICAL, true),
+		LEFT(Axis.HORIZONTAL, true),
+		RIGHT(Axis.HORIZONTAL, false);
 
 		private final Axis axis;
+		private final boolean inverted;
 
-		Direction(Axis axis) {
+		Direction(Axis axis, boolean inverted) {
 			this.axis = axis;
+			this.inverted = inverted;
 		}
 
 		public Axis getAxis() {
 			return axis;
+		}
+
+		public boolean isInverted() {
+			return inverted;
 		}
 	}
 }

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WAbstractSlider.java
@@ -72,7 +72,7 @@ public abstract class WAbstractSlider extends WWidget {
 		this.max = max;
 		this.axis = axis;
 		this.value = min;
-		this.direction = (axis == Axis.HORIZONTAL) ? Direction.RIGHT : Direction.UP;
+		this.direction = (axis == Axis.HORIZONTAL) ? Direction.LEFT : Direction.UP;
 	}
 
 	/**

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WBar.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WBar.java
@@ -6,6 +6,7 @@ import io.github.cottonmc.cotton.gui.GuiDescription;
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.screen.PropertyDelegate;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
@@ -100,7 +101,7 @@ public class WBar extends WWidget {
 	
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (bg!=null) {
 			ScreenDrawing.texturedRect(x, y, getWidth(), getHeight(), bg, 0xFFFFFFFF);
 		} else {

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WButton.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WButton.java
@@ -7,6 +7,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.widget.AbstractButtonWidget;
 import net.minecraft.client.sound.PositionedSoundInstance;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.Text;
 
@@ -33,7 +34,7 @@ public class WButton extends WWidget {
 	}
 	
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		boolean hovered = (mouseX>=0 && mouseY>=0 && mouseX<getWidth() && mouseY<getHeight());
 		int state = 1; //1=regular. 2=hovered. 0=disabled.
 		if (!enabled) state = 0;
@@ -60,7 +61,7 @@ public class WButton extends WWidget {
 				color = 0xFFFFA0;
 			}*/
 			
-			ScreenDrawing.drawStringWithShadow(label, alignment, x, y + ((20 - 8) / 2), width, color); //LibGuiClient.config.darkMode ? darkmodeColor : color);
+			ScreenDrawing.drawStringWithShadow(matrices, label, alignment, x, y + ((20 - 8) / 2), width, color); //LibGuiClient.config.darkMode ? darkmodeColor : color);
 		}
 	}
 	

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WClippedPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WClippedPanel.java
@@ -4,24 +4,11 @@ import net.minecraft.client.util.math.MatrixStack;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.util.Identifier;
 
 /**
  * A panel that is clipped to only render widgets inside its bounds.
  */
 public class WClippedPanel extends WPanel {
-	@Deprecated
-	protected Identifier mask;
-
-	/**
-	 * @deprecated {@code WClippedPanel} does not support clipping masks anymore.
-	 */
-	@Deprecated
-	public WClippedPanel setClippingMask(Identifier mask) {
-		this.mask = mask;
-		return this;
-	}
-	
 	@Override
 	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (getBackgroundPainter()!=null) getBackgroundPainter().paintBackground(x, y, this);

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WClippedPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WClippedPanel.java
@@ -1,5 +1,6 @@
 package io.github.cottonmc.cotton.gui.widget;
 
+import net.minecraft.client.util.math.MatrixStack;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.MinecraftClient;
@@ -22,7 +23,7 @@ public class WClippedPanel extends WPanel {
 	}
 	
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (getBackgroundPainter()!=null) getBackgroundPainter().paintBackground(x, y, this);
 
 		GL11.glEnable(GL11.GL_SCISSOR_TEST);
@@ -36,7 +37,7 @@ public class WClippedPanel extends WPanel {
 		GL11.glScissor((int) (x * scaleFactor), (int) (rawHeight - (y * scaleFactor) - scaledHeight), scaledWidth, scaledHeight);
 
 		for(WWidget child : children) {
-			child.paintBackground(x + child.getX(), y + child.getY(), mouseX-child.getX(), mouseY-child.getY());
+			child.paint(matrices, x + child.getX(), y + child.getY(), mouseX-child.getX(), mouseY-child.getY());
 		}
 
 		GL11.glDisable(GL11.GL_SCISSOR_TEST);

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WDynamicLabel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WDynamicLabel.java
@@ -3,6 +3,7 @@ package io.github.cottonmc.cotton.gui.widget;
 import io.github.cottonmc.cotton.gui.client.LibGuiClient;
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import io.github.cottonmc.cotton.gui.widget.data.Alignment;
+import net.minecraft.client.util.math.MatrixStack;
 
 import java.util.function.Supplier;
 
@@ -33,9 +34,9 @@ public class WDynamicLabel extends WWidget {
 	}
 
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		String tr = text.get();
-		ScreenDrawing.drawString(tr, alignment, x, y, this.getWidth(), LibGuiClient.config.darkMode ? darkmodeColor : color);
+		ScreenDrawing.drawString(matrices, tr, alignment, x, y, this.getWidth(), LibGuiClient.config.darkMode ? darkmodeColor : color);
 	}
 
 	@Override

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WItem.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WItem.java
@@ -54,17 +54,13 @@ public class WItem extends WWidget {
 	@Environment(EnvType.CLIENT)
 	@Override
 	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
-		RenderSystem.pushMatrix();
 		RenderSystem.enableDepthTest();
-		RenderSystem.translatef(x, y, 0);
 
 		MinecraftClient mc = MinecraftClient.getInstance();
 		ItemRenderer renderer = mc.getItemRenderer();
 		renderer.zOffset = 100f;
-		renderer.renderGuiItem(mc.player, items.get(current), getWidth() / 2 - 9, getHeight() / 2 - 9);
+		renderer.renderGuiItem(mc.player, items.get(current), x + getWidth() / 2 - 9, y + getHeight() / 2 - 9);
 		renderer.zOffset = 0f;
-
-		RenderSystem.popMatrix();
 	}
 
 	/**

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WItem.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WItem.java
@@ -6,6 +6,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
@@ -52,7 +53,7 @@ public class WItem extends WWidget {
 
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		RenderSystem.pushMatrix();
 		RenderSystem.enableDepthTest();
 		RenderSystem.translatef(x, y, 0);

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WItemSlot.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WItemSlot.java
@@ -10,6 +10,7 @@ import io.github.cottonmc.cotton.gui.client.BackgroundPainter;
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.inventory.Inventory;
 
 public class WItemSlot extends WWidget {
@@ -127,7 +128,7 @@ public class WItemSlot extends WWidget {
 	
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (backgroundPainter!=null) {
 			backgroundPainter.paintBackground(x, y, this);
 		} else {

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabel.java
@@ -7,8 +7,8 @@ import io.github.cottonmc.cotton.gui.widget.data.Alignment;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 
@@ -75,14 +75,14 @@ public class WLabel extends WWidget {
 	}
 
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
-		ScreenDrawing.drawString(text, alignment, x, y, this.getWidth(), LibGuiClient.config.darkMode ? darkmodeColor : color);
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
+		ScreenDrawing.drawString(matrices, text, alignment, x, y, this.getWidth(), LibGuiClient.config.darkMode ? darkmodeColor : color);
 
 		Text hoveredText = getTextAt(mouseX, mouseY);
 		if (hoveredText != null) {
 			Screen screen = MinecraftClient.getInstance().currentScreen;
 			if (screen instanceof TextHoverRendererScreen) {
-				((TextHoverRendererScreen) screen).renderTextHover(hoveredText, x + mouseX, y + mouseY);
+				((TextHoverRendererScreen) screen).renderTextHover(matrices, hoveredText, x + mouseX, y + mouseY);
 			}
 		}
 	}

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabeledSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabeledSlider.java
@@ -1,6 +1,5 @@
 package io.github.cottonmc.cotton.gui.widget;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import io.github.cottonmc.cotton.gui.widget.data.Alignment;
 import io.github.cottonmc.cotton.gui.widget.data.Axis;
@@ -8,7 +7,9 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.widget.AbstractButtonWidget;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.text.Text;
+import net.minecraft.util.math.Quaternion;
 
 import javax.annotation.Nullable;
 
@@ -22,6 +23,8 @@ import javax.annotation.Nullable;
  * @see WAbstractSlider for more information about listeners
  */
 public class WLabeledSlider extends WAbstractSlider {
+	private static final Quaternion ROTATION_Z_270 = Vector3f.POSITIVE_X.getDegreesQuaternion(270);
+
 	@Nullable private Text label = null;
 	@Nullable private LabelUpdater labelUpdater = null;
 	private Alignment labelAlignment = Alignment.CENTER;
@@ -163,11 +166,11 @@ public class WLabeledSlider extends WAbstractSlider {
 		int rotMouseX = axis == Axis.HORIZONTAL ? mouseX : (height - mouseY);
 		int rotMouseY = axis == Axis.HORIZONTAL ? mouseY : mouseX;
 
-		RenderSystem.pushMatrix();
-		RenderSystem.translatef(x, y, 0);
+		matrices.push();
+		matrices.translate(x, y, 0);
 		if (axis == Axis.VERTICAL) {
-			RenderSystem.translatef(0, height, 0);
-			RenderSystem.rotatef(270, 0, 0, 1);
+			matrices.translate(0, height, 0);
+			matrices.multiply(ROTATION_Z_270);
 		}
 		drawButton(0, 0, 0, aWidth);
 
@@ -190,7 +193,7 @@ public class WLabeledSlider extends WAbstractSlider {
 			int color = isMouseInsideBounds(mouseX, mouseY) ? 0xFFFFA0 : 0xE0E0E0;
 			ScreenDrawing.drawStringWithShadow(matrices, label, labelAlignment, 2, aHeight / 2 - 4, aWidth - 4, color);
 		}
-		RenderSystem.popMatrix();
+		matrices.pop();
 	}
 
 	// state = 1: regular, 2: hovered, 0: disabled/dragging

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabeledSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabeledSlider.java
@@ -164,7 +164,7 @@ public class WLabeledSlider extends WAbstractSlider {
 		int aWidth = axis == Axis.HORIZONTAL ? width : height;
 		int aHeight = axis == Axis.HORIZONTAL ? height : width;
 		int rotMouseX = axis == Axis.HORIZONTAL
-				? (direction == Direction.RIGHT ? width - mouseX : mouseX)
+				? (direction == Direction.LEFT ? width - mouseX : mouseX)
 				: (direction == Direction.UP ? height - mouseY : mouseY);
 		int rotMouseY = axis == Axis.HORIZONTAL ? mouseY : mouseX;
 

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabeledSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabeledSlider.java
@@ -7,6 +7,7 @@ import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.widget.AbstractButtonWidget;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
 
 import javax.annotation.Nullable;
@@ -156,7 +157,7 @@ public class WLabeledSlider extends WAbstractSlider {
 
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		int aWidth = axis == Axis.HORIZONTAL ? width : height;
 		int aHeight = axis == Axis.HORIZONTAL ? height : width;
 		int rotMouseX = axis == Axis.HORIZONTAL ? mouseX : (height - mouseY);
@@ -187,7 +188,7 @@ public class WLabeledSlider extends WAbstractSlider {
 
 		if (label != null) {
 			int color = isMouseInsideBounds(mouseX, mouseY) ? 0xFFFFA0 : 0xE0E0E0;
-			ScreenDrawing.drawStringWithShadow(label, labelAlignment, 2, aHeight / 2 - 4, aWidth - 4, color);
+			ScreenDrawing.drawStringWithShadow(matrices, label, labelAlignment, 2, aHeight / 2 - 4, aWidth - 4, color);
 		}
 		RenderSystem.popMatrix();
 	}

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabeledSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WLabeledSlider.java
@@ -163,7 +163,9 @@ public class WLabeledSlider extends WAbstractSlider {
 	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		int aWidth = axis == Axis.HORIZONTAL ? width : height;
 		int aHeight = axis == Axis.HORIZONTAL ? height : width;
-		int rotMouseX = axis == Axis.HORIZONTAL ? mouseX : (height - mouseY);
+		int rotMouseX = axis == Axis.HORIZONTAL
+				? (direction == Direction.RIGHT ? width - mouseX : mouseX)
+				: (direction == Direction.UP ? height - mouseY : mouseY);
 		int rotMouseY = axis == Axis.HORIZONTAL ? mouseY : mouseX;
 
 		matrices.push();

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WListPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WListPanel.java
@@ -61,14 +61,6 @@ public class WListPanel<D, W extends WWidget> extends WClippedPanel {
 		scrollBar.setMaxValue(data.size());
 		scrollBar.setParent(this);
 	}
-
-	/**
-	 * @deprecated Use {@link #WListPanel(List, Supplier, BiConsumer)} instead.
-	 */
-	@Deprecated
-	public WListPanel(List<D> data, Class<W> listItemClass, Supplier<W> supplier, BiConsumer<D, W> configurator) {
-		this(data, supplier, configurator);
-	}
 	
 	@Override
 	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WListPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WListPanel.java
@@ -7,6 +7,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import io.github.cottonmc.cotton.gui.widget.data.Axis;
+import net.minecraft.client.util.math.MatrixStack;
 
 /**
  * Similar to the RecyclerView in Android, this widget represents a scrollable list of items.
@@ -70,13 +71,13 @@ public class WListPanel<D, W extends WWidget> extends WClippedPanel {
 	}
 	
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (scrollBar.getValue()!=lastScroll) {
 			layout();
 			lastScroll = scrollBar.getValue();
 		}
 		
-		super.paintBackground(x, y, mouseX, mouseY);
+		super.paint(matrices, x, y, mouseX, mouseY);
 		/*
 		if (getBackgroundPainter()!=null) {
 			getBackgroundPainter().paintBackground(x, y, this);

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WListPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WListPanel.java
@@ -102,9 +102,7 @@ public class WListPanel<D, W extends WWidget> extends WClippedPanel {
 		this.children.add(scrollBar);
 		scrollBar.setLocation(this.width-scrollBar.getWidth(), 0);
 		scrollBar.setSize(8, this.height);
-		//scrollBar.window = 6;
-		scrollBar.setMaxValue(data.size());
-		
+
 		//super.layout();
 		
 		//System.out.println("Validating");
@@ -139,7 +137,7 @@ public class WListPanel<D, W extends WWidget> extends WClippedPanel {
 		
 		//Fix up the scrollbar handle and track metrics
 		scrollBar.setWindow(cellsHigh);
-		//scrollBar.setMaxValue(data.size());
+		scrollBar.setMaxValue(data.size());
 		int scrollOffset = scrollBar.getValue();
 		//System.out.println(scrollOffset);
 		

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WPanel.java
@@ -8,6 +8,7 @@ import io.github.cottonmc.cotton.gui.GuiDescription;
 import io.github.cottonmc.cotton.gui.client.BackgroundPainter;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
 
 /**
  * Panels are widgets tthat contain other widgets.
@@ -180,20 +181,11 @@ public abstract class WPanel extends WWidget {
 	
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (backgroundPainter!=null) backgroundPainter.paintBackground(x, y, this);
 		
 		for(WWidget child : children) {
-			child.paintBackground(x + child.getX(), y + child.getY(), mouseX-child.getX(), mouseY-child.getY());
-		}
-	}
-
-	@Environment(EnvType.CLIENT)
-	@Override
-	@Deprecated
-	public void paintForeground(int x, int y, int mouseX, int mouseY) {
-		for(WWidget child : children) {
-			child.paintForeground(x + child.getX(), y + child.getY(), mouseX, mouseY);
+			child.paint(matrices, x + child.getX(), y + child.getY(), mouseX-child.getX(), mouseY-child.getY());
 		}
 	}
 

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
@@ -129,7 +129,7 @@ public class WScrollBar extends WAbstractSlider {
 	}
 
 	public void setMaxValue(int max) {
-		super.setMaxValue(max);
+		super.setMaxValue(max - window);
 		checkValue();
 	}
 

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
@@ -5,6 +5,7 @@ import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
 
 public class WScrollBar extends WWidget {
 	protected Axis axis = Axis.HORIZONTAL;
@@ -32,7 +33,7 @@ public class WScrollBar extends WWidget {
 	}
 	
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (LibGuiClient.config.darkMode) {
 			ScreenDrawing.drawBeveledPanel(x, y, width, height, 0xFF_212121, 0xFF_2F2F2F, 0xFF_5D5D5D);
 		} else {

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
@@ -3,24 +3,16 @@ package io.github.cottonmc.cotton.gui.widget;
 import io.github.cottonmc.cotton.gui.client.LibGuiClient;
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import io.github.cottonmc.cotton.gui.widget.data.Axis;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.client.util.math.MatrixStack;
 
-public class WScrollBar extends WWidget {
-	protected Axis axis = Axis.HORIZONTAL;
-	protected int value;
-	protected int maxValue = 100;
+public class WScrollBar extends WAbstractSlider {
 	protected int window = 16;
-	
-	protected int anchor = -1;
-	protected int anchorValue = -1;
-	protected boolean sliding = false;
 
 	/**
 	 * Constructs a horizontal scroll bar.
 	 */
 	public WScrollBar() {
+		super(0, 100, Axis.HORIZONTAL);
 	}
 
 	/**
@@ -29,9 +21,21 @@ public class WScrollBar extends WWidget {
 	 * @param axis the axis
 	 */
 	public WScrollBar(Axis axis) {
-		this.axis = axis;
+		super(0, 100, axis);
 	}
-	
+
+	@Override
+	protected int getThumbWidth() {
+		return window;
+	}
+
+	@Override
+	protected boolean isMouseInsideBounds(int x, int y) {
+		return axis == Axis.HORIZONTAL
+				? (x >= getHandlePosition() + 1 && x <= getHandlePosition() + getHandleSize())
+				: (y >= getHandlePosition() + 1 && y <= getHandlePosition() + getHandleSize());
+	}
+
 	@Override
 	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (LibGuiClient.config.darkMode) {
@@ -39,12 +43,12 @@ public class WScrollBar extends WWidget {
 		} else {
 			ScreenDrawing.drawBeveledPanel(x, y, width, height, 0xFF_373737, 0xFF_8B8B8B, 0xFF_FFFFFF);
 		}
-		if (maxValue<=0) return;
+		if (getMaxValue()<=0) return;
 
 		// Handle colors
 		int top, middle, bottom;
 
-		if (sliding) {
+		if (dragging) {
 			if (LibGuiClient.config.darkMode) {
 				top = 0xFF_6C6C6C;
 				middle = 0xFF_2F2F2F;
@@ -87,7 +91,7 @@ public class WScrollBar extends WWidget {
 	 * Gets the on-axis size of the scrollbar handle in gui pixels 
 	 */
 	public int getHandleSize() {
-		float percentage = (window>=maxValue) ? 1f : window / (float)maxValue;
+		float percentage = (window>=getMaxValue()) ? 1f : window / (float)getMaxValue();
 		int bar = (axis==Axis.HORIZONTAL) ? width-2 : height-2;
 		int result = (int)(percentage*bar);
 		if (result<6) result = 6;
@@ -102,15 +106,8 @@ public class WScrollBar extends WWidget {
 		return bar-getHandleSize();
 	}
 	
-	public int pixelsToValues(int pixels) {
-		int bar = (axis==Axis.HORIZONTAL) ? width-2 : height-2;
-		//int bar = getMovableDistance();
-		float percent = pixels / (float)bar;
-		return (int)(percent*(maxValue-window));
-	}
-	
 	public int getHandlePosition() {
-		float percent = value / (float)Math.max(maxValue-window, 1);
+		float percent = value / (float)Math.max(getMaxValue()-window, 1);
 		return (int)(percent * getMovableDistance());
 	}
 	
@@ -119,75 +116,17 @@ public class WScrollBar extends WWidget {
 	 * window size
 	 */
 	public int getMaxScrollValue() {
-		return maxValue - window;
-	}
-	
-	protected void adjustSlider(int x, int y) {
-		
-		int delta = 0;
-		if (axis==Axis.HORIZONTAL) {
-			delta = x-anchor;
-		} else {
-			delta = y-anchor;
-		}
-		
-		int valueDelta = pixelsToValues(delta);
-		int valueNew = anchorValue + valueDelta;
-		
-		if (valueNew>getMaxScrollValue()) valueNew = getMaxScrollValue();
-		if (valueNew<0) valueNew = 0;
-		this.value = valueNew;
-	}
-	
-	@Override
-	public WWidget onMouseDown(int x, int y, int button) {
-		//TODO: Clicking before or after the handle should jump instead of scrolling
-		
-		if (axis==Axis.HORIZONTAL) {
-			anchor = x;
-			anchorValue = value;
-		} else {
-			anchor = y;
-			anchorValue = value;
-		}
-		sliding = true;
-		return this;
+		return getMaxValue() - window;
 	}
 
-	@Environment(EnvType.CLIENT)
-	@Override
-	public void onMouseDrag(int x, int y, int button) {
-		adjustSlider(x, y);
-	}
-
-	@Environment(EnvType.CLIENT)
-	@Override
-	public WWidget onMouseUp(int x, int y, int button) {
-		//TODO: Clicking before or after the handle should jump instead of scrolling
-		anchor = -1;
-		anchorValue = -1;
-		sliding = false;
-		return this;
-	}
-	
-	public int getValue() {
-		return value;
-	}
-
-	public WScrollBar setValue(int value) {
-		this.value = value;
+	public void setValue(int value) {
+		super.setValue(value);
 		checkValue();
-		return this;
 	}
 
-	public int getMaxValue() {
-		return maxValue;
-	}
-
-	public WScrollBar setMaxValue(int max) {
-		this.maxValue = max;
+	public void setMaxValue(int max) {
+		super.setMaxValue(max);
 		checkValue();
-		return this;
 	}
 
 	public int getWindow() {
@@ -204,8 +143,8 @@ public class WScrollBar extends WWidget {
 	 * and adjusts it if needed.
 	 */
 	protected void checkValue() {
-		if (this.value>maxValue-window) {
-			this.value = maxValue-window;
+		if (this.value>getMaxValue()-window) {
+			this.value = getMaxValue()-window;
 		}
 		if (this.value<0) this.value = 0;
 	}

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
@@ -30,7 +30,7 @@ public class WScrollBar extends WAbstractSlider {
 
 	@Override
 	protected int getThumbWidth() {
-		return window;
+		return Math.round(window * coordToValueRatio);
 	}
 
 	@Override
@@ -86,9 +86,24 @@ public class WScrollBar extends WAbstractSlider {
 
 		if (axis==Axis.HORIZONTAL) {
 			ScreenDrawing.drawBeveledPanel(x+1+getHandlePosition(), y+1, getHandleSize(), height-2, top, middle, bottom);
+
+			if (isFocused()) {
+				drawBeveledOutline(x+1+getHandlePosition(), y+1, getHandleSize(), height-2, 0xFF_FFFFA7, 0xFF_C9CA71, 0xFF_8C8F39);
+			}
 		} else {
 			ScreenDrawing.drawBeveledPanel(x+1, y+1+getHandlePosition(), width-2, getHandleSize(), top, middle, bottom);
+
+			if (isFocused()) {
+				drawBeveledOutline(x+1, y+1+getHandlePosition(), width-2, getHandleSize(), 0xFF_FFFFA7, 0xFF_C9CA71, 0xFF_8C8F39);
+			}
 		}
+	}
+
+	private static void drawBeveledOutline(int x, int y, int width, int height, int topleft, int center, int bottomright) {
+		ScreenDrawing.coloredRect(x,             y,              width - 1, 1,          topleft); //Top shadow
+		ScreenDrawing.coloredRect(x,             y + 1,          1,         height - 2, topleft); //Left shadow
+		ScreenDrawing.coloredRect(x + width - 1, y + 1,          1,         height - 1, bottomright); //Right hilight
+		ScreenDrawing.coloredRect(x + 1,         y + height - 1, width - 1, 1,          bottomright); //Bottom hilight
 	}
 	
 	/**
@@ -111,26 +126,12 @@ public class WScrollBar extends WAbstractSlider {
 	}
 	
 	public int getHandlePosition() {
-		float percent = value / (float)Math.max(getMaxValue()-window, 1);
+		float percent = value / (float)Math.max(getMaxValue(), 1);
 		return (int)(percent * getMovableDistance());
-	}
-	
-	/**
-	 * Gets the maximum scroll value achievable; this will typically be the maximum value minus the
-	 * window size
-	 */
-	public int getMaxScrollValue() {
-		return getMaxValue() - window;
-	}
-
-	public void setValue(int value) {
-		super.setValue(value);
-		checkValue();
 	}
 
 	public void setMaxValue(int max) {
 		super.setMaxValue(max - window);
-		checkValue();
 	}
 
 	public int getWindow() {
@@ -140,16 +141,5 @@ public class WScrollBar extends WAbstractSlider {
 	public WScrollBar setWindow(int window) {
 		this.window = window;
 		return this;
-	}
-
-	/**
-	 * Checks that the current value is in the correct range
-	 * and adjusts it if needed.
-	 */
-	protected void checkValue() {
-		if (this.value>getMaxValue()-window) {
-			this.value = getMaxValue()-window;
-		}
-		if (this.value<0) this.value = 0;
 	}
 }

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
@@ -22,6 +22,10 @@ public class WScrollBar extends WAbstractSlider {
 	 */
 	public WScrollBar(Axis axis) {
 		super(0, 100, axis);
+
+		if (axis == Axis.VERTICAL) {
+			setDirection(Direction.DOWN);
+		}
 	}
 
 	@Override

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
@@ -73,7 +73,7 @@ public class WSlider extends WAbstractSlider {
 			} else {
 				int trackY = y + height / 2 - TRACK_WIDTH / 2;
 				thumbX = direction == Direction.LEFT
-						? (width - THUMB_SIZE) + 1 - (int) (coordToValueRatio * (value - min))
+						? (width - THUMB_SIZE) - (int) (coordToValueRatio * (value - min))
 						: Math.round(coordToValueRatio * (value - min));
 				thumbY = height / 2 - THUMB_SIZE / 2;
 				thumbXOffset = 8;

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
@@ -72,7 +72,7 @@ public class WSlider extends WAbstractSlider {
 				ScreenDrawing.texturedRect(trackX, y + height, TRACK_WIDTH, 1, texture, 16*px, 2*px, 22*px, 3*px, 0xFFFFFFFF);
 			} else {
 				int trackY = y + height / 2 - TRACK_WIDTH / 2;
-				thumbX = direction == Direction.RIGHT
+				thumbX = direction == Direction.LEFT
 						? (width - THUMB_SIZE) + 1 - (int) (coordToValueRatio * (value - min))
 						: Math.round(coordToValueRatio * (value - min));
 				thumbY = height / 2 - THUMB_SIZE / 2;

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
@@ -6,6 +6,7 @@ import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
 import javax.annotation.Nullable;
@@ -52,7 +53,7 @@ public class WSlider extends WAbstractSlider {
 	@SuppressWarnings("SuspiciousNameCombination")
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (backgroundPainter != null) {
 			backgroundPainter.paintBackground(x, y, this);
 		} else {

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
@@ -62,7 +62,9 @@ public class WSlider extends WAbstractSlider {
 			if (axis == Axis.VERTICAL) {
 				int trackX = x + width / 2 - TRACK_WIDTH / 2;
 				thumbX = width / 2 - THUMB_SIZE / 2;
-				thumbY = height - THUMB_SIZE + 1 - (int) (coordToValueRatio * (value - min));
+				thumbY = direction == Direction.UP
+						? (height - THUMB_SIZE) + 1 - (int) (coordToValueRatio * (value - min))
+						: Math.round(coordToValueRatio * (value - min));
 				thumbXOffset = 0;
 
 				ScreenDrawing.texturedRect(trackX, y + 1, TRACK_WIDTH, 1, texture, 16*px, 0*px, 22*px, 1*px, 0xFFFFFFFF);
@@ -70,7 +72,9 @@ public class WSlider extends WAbstractSlider {
 				ScreenDrawing.texturedRect(trackX, y + height, TRACK_WIDTH, 1, texture, 16*px, 2*px, 22*px, 3*px, 0xFFFFFFFF);
 			} else {
 				int trackY = y + height / 2 - TRACK_WIDTH / 2;
-				thumbX = Math.round(coordToValueRatio * (value - min));
+				thumbX = direction == Direction.RIGHT
+						? (width - THUMB_SIZE) + 1 - (int) (coordToValueRatio * (value - min))
+						: Math.round(coordToValueRatio * (value - min));
 				thumbY = height / 2 - THUMB_SIZE / 2;
 				thumbXOffset = 8;
 

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSlider.java
@@ -30,11 +30,6 @@ public class WSlider extends WAbstractSlider {
 		super(min, max, axis);
 	}
 
-	@Deprecated
-	public WSlider(int max, Axis axis) {
-		this(0, max, axis);
-	}
-
 	@Override
 	protected int getThumbWidth() {
 		return THUMB_SIZE;

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSprite.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSprite.java
@@ -3,6 +3,7 @@ package io.github.cottonmc.cotton.gui.widget;
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
 public class WSprite extends WWidget {
@@ -119,7 +120,7 @@ public class WSprite extends WWidget {
 
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (singleImage) {
 			ScreenDrawing.texturedRect(x, y, getWidth(), getHeight(), frames[0], u1, v1, u2, v2, tint);
 		} else {

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WText.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WText.java
@@ -9,7 +9,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.util.Texts;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 
@@ -73,7 +73,7 @@ public class WText extends WWidget {
 
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (wrappedLines == null || wrappingScheduled) {
 			wrapLines();
 			wrappingScheduled = false;
@@ -84,14 +84,14 @@ public class WText extends WWidget {
 			Text line = wrappedLines.get(i);
 			int c = LibGuiClient.config.darkMode ? darkmodeColor : color;
 
-			ScreenDrawing.drawString(line, alignment, x, y + i * font.fontHeight, width, c);
+			ScreenDrawing.drawString(matrices, line, alignment, x, y + i * font.fontHeight, width, c);
 		}
 
 		Text hoveredText = getTextAt(mouseX, mouseY);
 		if (hoveredText != null) {
 			Screen screen = MinecraftClient.getInstance().currentScreen;
 			if (screen instanceof TextHoverRendererScreen) {
-				((TextHoverRendererScreen) screen).renderTextHover(hoveredText, x + mouseX, y + mouseY);
+				((TextHoverRendererScreen) screen).renderTextHover(matrices, hoveredText, x + mouseX, y + mouseY);
 			}
 		}
 	}

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WTextField.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WTextField.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.client.util.math.MatrixStack;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.opengl.GL11;
 
@@ -310,7 +311,7 @@ public class WTextField extends WWidget {
 	}*/
 
 	@Environment(EnvType.CLIENT)
-	public void renderButton(int x, int y) {
+	protected void renderTextField(MatrixStack matrices, int x, int y) {
 		if (this.font==null) this.font = MinecraftClient.getInstance().textRenderer;
 		
 		int borderColor = (this.isFocused()) ? 0xFF_FFFFA0 : 0xFF_A0A0A0;
@@ -347,16 +348,16 @@ public class WTextField extends WWidget {
 		int preCursorAdvance = textX;
 		if (!trimText.isEmpty()) {
 			String string_2 = trimText.substring(0,adjustedCursor);
-			preCursorAdvance = font.drawWithShadow(ScreenDrawing.getMatrices(), string_2, textX, textY, textColor);
+			preCursorAdvance = font.drawWithShadow(matrices, string_2, textX, textY, textColor);
 		}
 
 		if (adjustedCursor<trimText.length()) {
-			font.drawWithShadow(ScreenDrawing.getMatrices(), trimText.substring(adjustedCursor), preCursorAdvance-1, (float)textY, textColor);
+			font.drawWithShadow(matrices, trimText.substring(adjustedCursor), preCursorAdvance-1, (float)textY, textColor);
 		}
 			
 
 		if (text.length()==0 && this.suggestion != null) {
-			font.drawWithShadow(ScreenDrawing.getMatrices(), this.suggestion, textX, textY, -8355712);
+			font.drawWithShadow(matrices, this.suggestion, textX, textY, 0xFF808080);
 		}
 
 		//int var10002;
@@ -378,7 +379,7 @@ public class WTextField extends WWidget {
 			//	DrawableHelper.fill(int_9, var10001, var10002, var10003 + 9, -3092272);
 				
 			} else {
-				font.drawWithShadow(ScreenDrawing.getMatrices(), "_", preCursorAdvance, textY, textColor);
+				font.drawWithShadow(matrices, "_", preCursorAdvance, textY, textColor);
 			}
 		}
 
@@ -510,7 +511,7 @@ public class WTextField extends WWidget {
 	}
 	
 	@Override
-	public void paintBackground(int x, int y) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		
 		/*
 		if (isFocused()) {
@@ -527,7 +528,7 @@ public class WTextField extends WWidget {
 		//int ofs = MinecraftClient.getInstance().textRenderer.getStringWidth(this.text);
 		ScreenDrawing.rect(x+OFFSET_X_TEXT+getCaretOffset(this.text, cursor), y+OFFSET_Y_TEXT-2, 1, OFFSET_Y_TEXT*2, 0xFFE0E0E0);*/
 		
-		renderButton(x, y);
+		renderTextField(matrices, x, y);
 	}
 
 	@Environment(EnvType.CLIENT)

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WToggleButton.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WToggleButton.java
@@ -2,11 +2,11 @@ package io.github.cottonmc.cotton.gui.widget;
 
 import io.github.cottonmc.cotton.gui.client.LibGuiClient;
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
-import io.github.cottonmc.cotton.gui.widget.data.Alignment;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.sound.PositionedSoundInstance;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -72,11 +72,11 @@ public class WToggleButton extends WWidget {
 
 	@Environment(EnvType.CLIENT)
 	@Override
-	public void paintBackground(int x, int y) {
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		ScreenDrawing.texturedRect(x, y, 18, 18, isOn ? onImage : offImage, 0xFFFFFFFF);
 		
 		if (label!=null) {
-			ScreenDrawing.drawString(label, x + 22, y+6, LibGuiClient.config.darkMode ? darkmodeColor : color);
+			ScreenDrawing.drawString(matrices, label, x + 22, y+6, LibGuiClient.config.darkMode ? darkmodeColor : color);
 		}
 	}
 	

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WToggleButton.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WToggleButton.java
@@ -54,22 +54,6 @@ public class WToggleButton extends WWidget {
 		this.label = label;
 	}
 
-	/**
-	 * @deprecated Use {@link #WToggleButton(Identifier, Identifier)} instead.
-	 */
-	@Deprecated
-	public WToggleButton(Identifier onImage, Identifier offImage, int width, int height) {
-		this(onImage, offImage);
-	}
-
-	/**
-	 * @deprecated Use {@link #WToggleButton(Identifier, Identifier, Text)} instead.
-	 */
-	@Deprecated
-	public WToggleButton(Text label, Identifier onImage, Identifier offImage, int width, int height) {
-		this(onImage, offImage, label);
-	}
-
 	@Environment(EnvType.CLIENT)
 	@Override
 	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
@@ -105,16 +89,6 @@ public class WToggleButton extends WWidget {
 	public boolean getToggle() { return this.isOn; }
 	public void setToggle(boolean on) { this.isOn = on; }
 
-	/**
-	 * Set on toggle handler
-	 *
-	 * @deprecated Use {@link #setOnToggle(Consumer)}
-	 */
-	@Deprecated
-	public void setOnToggle(Runnable r) {
-		this.onToggle = on -> r.run();
-	}
-
 	@Nullable
 	public Consumer<Boolean> getOnToggle() {
 		return this.onToggle;
@@ -133,14 +107,6 @@ public class WToggleButton extends WWidget {
 	public WToggleButton setLabel(@Nullable Text label) {
 		this.label = label;
 		return this;
-	}
-
-	/**
-	 * @deprecated Use {@link #setColor} instead.
-	 */
-	@Deprecated
-	public WToggleButton color(int light, int dark) {
-		return setColor(light, dark);
 	}
 
 	public WToggleButton setColor(int light, int dark) {

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WWidget.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WWidget.java
@@ -9,7 +9,6 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 
 import javax.annotation.Nullable;
@@ -313,12 +312,6 @@ public class WWidget {
 		List<Text> info = new ArrayList<>();
 		addTooltip(info);
 
-		List<String> stringInfo = new ArrayList<>();
-		addInformation(stringInfo);
-		for (String line : stringInfo) {
-			info.add(new LiteralText(line));
-		}
-
 		if (info.size() == 0)
 			return;
 
@@ -332,15 +325,6 @@ public class WWidget {
 	 */
 	public void validate(GuiDescription host) {
 		//valid = true;
-	}
-	
-	/**
-	 * Adds information to this widget's tooltip. If information remains empty after this call, no tooltip will be drawn.
-	 * @param information List containing all previous tooltip data.
-	 * @deprecated Replaced with {@link #addTooltip(List)}
-	 */
-	@Deprecated
-	public void addInformation(List<String> information) {
 	}
 
 	/**

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WWidget.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WWidget.java
@@ -9,6 +9,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
 
 import javax.annotation.Nullable;
@@ -103,11 +104,11 @@ public class WWidget {
 			return getY() + parent.getAbsoluteY();
 		}
 	}
-	
+
 	public int getWidth() {
 		return width;
 	}
-	
+
 	public int getHeight() {
 		return height;
 	}
@@ -129,7 +130,7 @@ public class WWidget {
 	public void setParent(WPanel parent) {
 		this.parent = parent;
 	}
-	
+
 	/**
 	 * Notifies this widget that the mouse has been pressed while inside its bounds
 	 * @param x The X coordinate of the event, in widget-space (0 is the left edge of this widget)
@@ -140,7 +141,7 @@ public class WWidget {
 	public WWidget onMouseDown(int x, int y, int button) {
 		return this;
 	}
-	
+
 	/**
 	 * Notifies this widget that the mouse has been moved while pressed and inside its bounds.
 	 *
@@ -168,7 +169,7 @@ public class WWidget {
 	@Environment(EnvType.CLIENT)
 	public void onMouseDrag(int x, int y, int button) {
 	}
-	
+
 	/**
 	 * Notifies this widget that the mouse has been released while inside its bounds
 	 * @param x The X coordinate of the event, in widget-space (0 is the left edge of this widget)
@@ -179,7 +180,7 @@ public class WWidget {
 	public WWidget onMouseUp(int x, int y, int button) {
 		return this;
 	}
-	
+
 	/**
 	 * Notifies this widget that the mouse has been pressed and released, both while inside its bounds.
 	 * @param x The X coordinate of the event, in widget-space (0 is the left edge of this widget)
@@ -189,7 +190,7 @@ public class WWidget {
 	@Environment(EnvType.CLIENT)
 	public void onClick(int x, int y, int button) {
 	}
-	
+
 	/**
 	 * Notifies this widget that the mouse has been scrolled inside its bounds.
 	 * @param x The X coordinate of the event, in widget-space (0 is the left edge of this widget)
@@ -210,7 +211,7 @@ public class WWidget {
 	@Environment(EnvType.CLIENT)
 	public void onMouseMove(int x, int y) {
 	}
-	
+
 	/**
 	 * Notifies this widget that a character has been typed. This method is subject to key repeat,
 	 * and may be called for characters that do not directly have a corresponding keyboard key.
@@ -219,7 +220,7 @@ public class WWidget {
 	@Environment(EnvType.CLIENT)
 	public void onCharTyped(char ch) {
 	}
-	
+
 	/**
 	 * Notifies this widget that a key has been pressed.
 	 * @param key the GLFW scancode of the key
@@ -227,7 +228,7 @@ public class WWidget {
 	@Environment(EnvType.CLIENT)
 	public void onKeyPressed(int ch, int key, int modifiers) {
 	}
-	
+
 	/**
 	 * Notifies this widget that a key has been released
 	 * @param key the GLFW scancode of the key
@@ -235,20 +236,20 @@ public class WWidget {
 	@Environment(EnvType.CLIENT)
 	public void onKeyReleased(int ch, int key, int modifiers) {
 	}
-	
+
 	/** Notifies this widget that it has gained focus */
 	public void onFocusGained() {
 	}
-	
+
 	/** Notifies this widget that it has lost focus */
 	public void onFocusLost() {
 	}
-	
+
 	public boolean isFocused() {
 		if (host==null) return false;
 		return host.isFocused(this);
 	}
-	
+
 	public void requestFocus() {
 		if (host!=null) {
 			host.requestFocus(this);
@@ -256,15 +257,15 @@ public class WWidget {
 			System.out.println("host is null");
 		}
 	}
-	
+
 	public void releaseFocus() {
 		if (host!=null) host.releaseFocus(this);
 	}
-	
+
 	public boolean canFocus() {
 		return false;
 	}
-	
+
 	/**
 	 * Creates "heavyweight" component peers
 	 * @param c the top-level Container that will hold the peers
@@ -272,22 +273,19 @@ public class WWidget {
 	public void createPeers(GuiDescription c) {
 		host=c;
 	}
-	
+
+	/**
+	 * Paints this widget.
+	 *
+	 * @param matrices the rendering matrix stack
+	 * @param x        this widget's X coordinate on the screen
+	 * @param y        this widget's Y coordinate on the screen
+	 * @param mouseX   the X coordinate of the cursor
+	 * @param mouseY   the X coordinate of the cursor
+	 * @since 2.0.0
+	 */
 	@Environment(EnvType.CLIENT)
-	public void paintBackground(int x, int y, int mouseX, int mouseY) {
-		this.paintBackground(x, y);
-	}
-	
-	@Environment(EnvType.CLIENT)
-	public void paintBackground(int x, int y) {
-	}
-	
-	@Deprecated
-	@Environment(EnvType.CLIENT)
-	public void paintForeground(int x, int y, int mouseX, int mouseY) {
-		//if (mouseX >= x && mouseX < x+getWidth() && mouseY >= y && mouseY < y+getHeight()) {
-		//	renderTooltip(mouseX, mouseY);
-		//}
+	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 	}
 
 	/**
@@ -302,13 +300,13 @@ public class WWidget {
 	public boolean isWithinBounds(int x, int y) {
 		return x>=0 && y>=0 && x<this.width && y<this.height;
 	}
-	
+
 	/**
 	 * Internal method to render tooltip data. This requires an overriden {@link #addTooltip(List)
 	 * addTooltip} method to insert data into the tooltip - without this, the method returns early, because no work
 	 */
 	@Environment(EnvType.CLIENT)
-	public void renderTooltip(int x, int y, int tX, int tY) {
+	public void renderTooltip(MatrixStack matrices, int x, int y, int tX, int tY) {
 		List<Text> info = new ArrayList<>();
 		addTooltip(info);
 
@@ -316,9 +314,9 @@ public class WWidget {
 			return;
 
 		Screen screen = MinecraftClient.getInstance().currentScreen;
-		screen.renderTooltip(ScreenDrawing.getMatrices(), info, tX+x, tY+y);
+		screen.renderTooltip(matrices, info, tX+x, tY+y);
 	}
-	
+
 	/**
 	 * Creates component peers, lays out children, and initializes animation data for this Widget and all its children.
 	 * The host container must clear any heavyweight peers from its records before this method is called.
@@ -333,7 +331,7 @@ public class WWidget {
 	 */
 	public void addTooltip(List<Text> tooltip) {
 	}
-	
+
 	/**
 	 * Find the most specific child node at this location. For non-panel widgets, returns this widget.
 	 */


### PR DESCRIPTION
- Make `CottonCraftingController` extend `ScreenHandler` directly, rename back to `CottonInventoryController`
  - Closes #39.
- `paintBackground` -> `paint`, removed `paintForeground`. Closes #42.
  - `paint` takes the `MatrixStack` as well. Closes #52.
- Removed all deprecated members from every class.
- Text
  - Renamed `WTextField.renderButton` to `renderTextField` and made it protected.
  - All text rendering methods in `ScreenDrawing` also take a matrix stack now.
- Sliders
  - Sliders can have a direction now that isn't up or towards the right.
  - Scroll bars are now `WAbstractSlider`s.