### PR TITLE
implement a WTiledSprite widget

### DIFF
--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
@@ -48,7 +48,7 @@ public class TestClientGui extends LightweightGuiDescription {
 			500, // animation speed
 			new Identifier("minecraft:textures/block/birch_planks.png"),
 			new Identifier("minecraft:textures/block/dark_oak_planks.png"),
-			new Identifier("minecraft:textures/block/jungle_plan.png")
+			new Identifier("minecraft:textures/block/jungle_planks.png")
 		);
 		root.add(wood, 3, 3, 2, 2);
 		root.add(title, 0, 0);
@@ -151,4 +151,3 @@ public class TestClientGui extends LightweightGuiDescription {
 		}
 	}
 }
-

--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
@@ -43,7 +43,13 @@ public class TestClientGui extends LightweightGuiDescription {
 				tooltip.add(new LiteralText("Radical!"));
 			}
 		};
-		WTiledSprite wood = new WTiledSprite(new Identifier("minecraft:textures/block/birch_planks.png"), 8, 8);
+		WTiledSprite wood = new WTiledSprite(
+			8, 8, // tile width and height
+			500, // animation speed
+			new Identifier("minecraft:textures/block/birch_planks.png"),
+			new Identifier("minecraft:textures/block/dark_oak_planks.png"),
+			new Identifier("minecraft:textures/block/jungle_plan.png")
+		);
 		root.add(wood, 3, 3, 2, 2);
 		root.add(title, 0, 0);
 		

--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
@@ -1,20 +1,15 @@
 package io.github.cottonmc.test.client;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiConsumer;
 
 import io.github.cottonmc.cotton.gui.client.BackgroundPainter;
 import io.github.cottonmc.cotton.gui.client.LightweightGuiDescription;
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
-import io.github.cottonmc.cotton.gui.widget.WButton;
 import io.github.cottonmc.cotton.gui.widget.WGridPanel;
 import io.github.cottonmc.cotton.gui.widget.WLabel;
-import io.github.cottonmc.cotton.gui.widget.WListPanel;
-import io.github.cottonmc.cotton.gui.widget.WPlainPanel;
 import io.github.cottonmc.cotton.gui.widget.WSlider;
-import io.github.cottonmc.cotton.gui.widget.WSprite;
 import io.github.cottonmc.cotton.gui.widget.WTextField;
+import io.github.cottonmc.cotton.gui.widget.WTiledSprite;
 import io.github.cottonmc.cotton.gui.widget.WWidget;
 import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import io.github.cottonmc.cotton.gui.widget.data.Color;
@@ -42,13 +37,14 @@ public class TestClientGui extends LightweightGuiDescription {
 	public TestClientGui() {
 		WGridPanel root = new WGridPanel(22);
 		this.setRootPanel(root);
-		
 		WLabel title = new WLabel(new LiteralText("Client Test Gui"), WLabel.DEFAULT_TEXT_COLOR) {
 			@Override
 			public void addTooltip(List<Text> tooltip) {
 				tooltip.add(new LiteralText("Radical!"));
 			}
 		};
+		WTiledSprite wood = new WTiledSprite(new Identifier("minecraft:textures/block/birch_planks.png"), 8, 8);
+		root.add(wood, 3, 3, 2, 2);
 		root.add(title, 0, 0);
 		
 		WTextField text = new WTextField();

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSprite.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSprite.java
@@ -152,6 +152,7 @@ public class WSprite extends WWidget {
 		}
 	}
 
+	@Environment(EnvType.CLIENT)
 	public void paintFrame(int x, int y, Identifier texture) {
 		ScreenDrawing.texturedRect(x, y, getWidth(), getHeight(), texture, u1, v1, u2, v2, tint);
 	}

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSprite.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSprite.java
@@ -123,7 +123,7 @@ public class WSprite extends WWidget {
 	@Override
 	public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
 		if (singleImage) {
-			ScreenDrawing.texturedRect(x, y, getWidth(), getHeight(), frames[0], u1, v1, u2, v2, tint);
+			paintFrame(x, y, frames[0]);
 		} else {
 			//grab the system time at the very start of the frame.
 			long now = System.nanoTime() / 1_000_000L;
@@ -133,7 +133,7 @@ public class WSprite extends WWidget {
 			if (!inBounds) currentFrame = 0;
 			//assemble and draw the frame calculated last iteration.
 			Identifier currentFrameTex = frames[currentFrame];
-			ScreenDrawing.texturedRect(x, y, getWidth(), getHeight(), currentFrameTex, u1, v1, u2, v2, tint);
+			paintFrame(x, y, currentFrameTex);
 
 			//calculate how much time has elapsed since the last animation change, and change the frame if necessary.
 			long elapsed = now - lastFrame;
@@ -150,5 +150,9 @@ public class WSprite extends WWidget {
 			//frame is over; this frame is becoming the last frame so write the time to lastFrame
 			this.lastFrame = now;
 		}
+	}
+
+	public void paintFrame(int x, int y, Identifier texture) {
+		ScreenDrawing.texturedRect(x, y, getWidth(), getHeight(), texture, u1, v1, u2, v2, tint);
 	}
 }

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WTiledSprite.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WTiledSprite.java
@@ -1,27 +1,50 @@
 package io.github.cottonmc.cotton.gui.widget;
 
 import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.util.Identifier;
 
-// It's a Sprite that can be tiled, but does not support animations
+/**
+ * A sprite whose texture will be tiled.
+ *
+ * @since 2.0.0
+ */
 public class WTiledSprite extends WSprite {
-  public int tileWidth = 20;
-  public int tileHeight = 20;
+	private int tileWidth;
+	private int tileHeight;
 
-	WTiledSprite(Identifier image) {
-		super(image);
-	}
-
-	public WTiledSprite(Identifier image, int tileWidth, int tileHeight) {
+	/**
+	 * Create a tiled sprite.
+	 * 
+	 * @param tileWidth  The width a tile
+	 * @param tileHeight The height of a tile
+	 * @param image      The image to tile
+	 */
+	public WTiledSprite(int tileWidth, int tileHeight, Identifier image) {
 		super(image);
 		this.tileWidth = tileWidth;
 		this.tileHeight = tileHeight;
 	}
-	
+
 	/**
-	 * Sets the tiling size. This determines how often the image will repeat.
+	 * Create a new animated tiled sprite.
 	 *
-	 * @param width the new tiling width
+	 * @param tileWidth  The width a tile
+	 * @param tileHeight The height of a tile
+	 * @param frameTime  How long in milliseconds to display for. (1 tick = 50 ms)
+	 * @param frames     The locations of the frames of the animation.
+	 */
+	public WTiledSprite(int tileWidth, int tileHeight, int frameTime, Identifier... frames) {
+		super(frameTime, frames);
+		this.tileWidth = tileWidth;
+		this.tileHeight = tileHeight;
+	}
+
+	/**
+	 * Sets the tiling size. This determines how often the texture will repeat.
+	 *
+	 * @param width  the new tiling width
 	 * @param height the new tiling height
 	 */
 	public void setTileSize(int width, int height) {
@@ -29,26 +52,24 @@ public class WTiledSprite extends WSprite {
 		tileHeight = height;
 	}
 
+	@Environment(EnvType.CLIENT)
 	@Override
 	public void paintFrame(int x, int y, Identifier texture) {
 		// Y Direction (down)
-		for (int tileYOffset = 0; tileYOffset < height; tileYOffset+=tileHeight) {
+		for (int tileYOffset = 0; tileYOffset < height; tileYOffset += tileHeight) {
 			// X Direction (right)
-			for (int tileXOffset = 0; tileXOffset < width; tileXOffset+=tileWidth) {
+			for (int tileXOffset = 0; tileXOffset < width; tileXOffset += tileWidth) {
 				// draw the texture
 				ScreenDrawing.texturedRect(
-					// at the correct position using tileXOffset and tileYOffset
-					x + tileXOffset,
-					y + tileYOffset,
-					// but using the set tileWidth and tileHeight instead of the full height and width
-					tileWidth,
-					tileHeight,
-					// render the current texture
-					texture,
-					// clips the texture if wanted
-					u1, v1, u2, v2,
-					tint
-				);
+						// at the correct position using tileXOffset and tileYOffset
+						x + tileXOffset, y + tileYOffset,
+						// but using the set tileWidth and tileHeight instead of the full height and
+						// width
+						tileWidth, tileHeight,
+						// render the current texture
+						texture,
+						// clips the texture if wanted
+						u1, v1, u2, v2, tint);
 			}
 		}
 	}

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WTiledSprite.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WTiledSprite.java
@@ -1,0 +1,55 @@
+package io.github.cottonmc.cotton.gui.widget;
+
+import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
+import net.minecraft.util.Identifier;
+
+// It's a Sprite that can be tiled, but does not support animations
+public class WTiledSprite extends WSprite {
+  public int tileWidth = 20;
+  public int tileHeight = 20;
+
+	WTiledSprite(Identifier image) {
+		super(image);
+	}
+
+	public WTiledSprite(Identifier image, int tileWidth, int tileHeight) {
+		super(image);
+		this.tileWidth = tileWidth;
+		this.tileHeight = tileHeight;
+	}
+	
+	/**
+	 * Sets the tiling size. This determines how often the image will repeat.
+	 *
+	 * @param width the new tiling width
+	 * @param height the new tiling height
+	 */
+	public void setTileSize(int width, int height) {
+		tileWidth = width;
+		tileHeight = height;
+	}
+
+	@Override
+	public void paintFrame(int x, int y, Identifier texture) {
+		// Y Direction (down)
+		for (int tileYOffset = 0; tileYOffset < height; tileYOffset+=tileHeight) {
+			// X Direction (right)
+			for (int tileXOffset = 0; tileXOffset < width; tileXOffset+=tileWidth) {
+				// draw the texture
+				ScreenDrawing.texturedRect(
+					// at the correct position using tileXOffset and tileYOffset
+					x + tileXOffset,
+					y + tileYOffset,
+					// but using the set tileWidth and tileHeight instead of the full height and width
+					tileWidth,
+					tileHeight,
+					// render the current texture
+					texture,
+					// clips the texture if wanted
+					u1, v1, u2, v2,
+					tint
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new `WTiledSprite` that renders the same as `WSprite` but tiles the texture according to a tiledWidth and tiledHeight setting.

I implemented this by moving the actual draw functionality in `WSprite` into a method called `paintFrame`. I did this to avoid duplicate code, so `WTiledSprite` only has to overwrite that method.

Keep in mind that this is my first contribution to any minecraft mod, the code might be crap.

I also tried to follow your [contributing guidelines](https://github.com/CottonMC/.github/blob/master/CONTRIBUTING.md#pull-requests) but the link to the ["instructions in the template"](https://github.com/CottonMC/.github/blob/master/PULL_REQUEST_TEMPLATE.md) is broken.

## Preview of GuiTest

![Screenshot from 2020-06-13 12-45-03](https://user-images.githubusercontent.com/3409958/84566871-e8b1cf00-ad74-11ea-9c89-93a52c614417.png)
