### PR TITLE
WScrollBar: More intuitive drag scroll threshold

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollBar.java
@@ -130,8 +130,7 @@ public class WScrollBar extends WWidget {
 	}
 	
 	public int pixelsToValues(int pixels) {
-		int bar = (axis==Axis.HORIZONTAL) ? width-2 : height-2;
-		//int bar = getMovableDistance();
+		int bar = getMovableDistance();
 		float percent = pixels / (float)bar;
 		return (int)(percent*(maxValue-window));
 	}


### PR DESCRIPTION
Use the movable area (ie. scroll bar length minus handle length) instead of just the scroll bar length.
This makes it so the handle actually feels like it's sticking to the cursor while scrolling.