### PR TITLE
Fix WScrollPanel validation issue

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollPanel.java
@@ -1,5 +1,7 @@
 package io.github.cottonmc.cotton.gui.widget;
 
+import io.github.cottonmc.cotton.gui.GuiDescription;
+
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.util.TriState;
@@ -148,5 +150,13 @@ public class WScrollPanel extends WClippedPanel {
 		}
 
 		return InputResult.IGNORED;
+	}
+
+	@Override
+	public void validate(GuiDescription c) {
+		//you have to validate these ones manually since they are not in children list
+		this.horizontalScrollBar.validate(c);
+		this.verticalScrollBar.validate(c);
+		super.validate(c);
 	}
 }

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollPanel.java
@@ -1,12 +1,11 @@
 package io.github.cottonmc.cotton.gui.widget;
 
-import io.github.cottonmc.cotton.gui.GuiDescription;
-
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.client.util.math.MatrixStack;
 
+import io.github.cottonmc.cotton.gui.GuiDescription;
 import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import io.github.cottonmc.cotton.gui.widget.data.InputResult;
 


### PR DESCRIPTION
Basically it would spam the log (and thanks to visual stuff, the logger) with unfocused stuff about WScrollPanel. That is because WScrollBar would call request when touched, but it had not been validated. This fixes that with a two line fix. 