### PR TITLE
Fix texturedRect() not blending transparent textures

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/client/ScreenDrawing.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/ScreenDrawing.java
@@ -141,6 +141,7 @@ public class ScreenDrawing {
 		Tessellator tessellator = Tessellator.getInstance();
 		BufferBuilder buffer = tessellator.getBuffer();
 		Matrix4f model = matrices.peek().getModel();
+		RenderSystem.enableBlend();
 		RenderSystem.setShaderTexture(0, texture);
 		RenderSystem.setShaderColor(r, g, b, opacity);
 		RenderSystem.setShader(GameRenderer::getPositionTexShader);
@@ -151,6 +152,7 @@ public class ScreenDrawing {
 		buffer.vertex(model, x,         y,          0).texture(u1, v1).next();
 		buffer.end();
 		BufferRenderer.draw(buffer);
+		RenderSystem.disableBlend();
 	}
 
 	/**


### PR DESCRIPTION
In pre-1.17 LibGui versions, `texturedRect()` was able to blend transparent textures with alpha values between 0 and 1.

Here's some comparison screenshots between 1.17 and 1.16 versions: https://github.com/minepkg/test-utils/pull/6#issuecomment-880955356

This is a regression from https://github.com/CottonMC/LibGui/commit/c321cfc512e7277f934276657ca21b89cae84794#diff-33951c5440c0f9d174429cbffd7b5657d69486889a3e70b4ae750c360a3da8ecL146 which removed the call to `RenderSystem.enableBlend()`.
The fix is to simply add the blend calls back in.