### PR TITLE
Allow WGridPanel to have gaps between widgets.

### DIFF
--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/LibGuiTestClient.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/LibGuiTestClient.java
@@ -1,6 +1,7 @@
 package io.github.cottonmc.test.client;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
@@ -20,6 +21,7 @@ import io.github.cottonmc.test.TestDescription;
 
 import java.util.function.Function;
 
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
 
 public class LibGuiTestClient implements ClientModInitializer {
@@ -46,6 +48,15 @@ public class LibGuiTestClient implements ClientModInitializer {
 						.then(literal("scrolling").executes(openScreen(client -> new ScrollingTestGui())))
 						.then(literal("insets").executes(openScreen(client -> new InsetsTestGui())))
 						.then(literal("textfield").executes(openScreen(client -> new TextFieldTestGui())))
+						.then(literal("paddings")
+								.then(argument("horizontal", IntegerArgumentType.integer(0))
+										.then(argument("vertical", IntegerArgumentType.integer(0))
+												.executes(context -> {
+													var hori = IntegerArgumentType.getInteger(context, "horizontal");
+													var vert = IntegerArgumentType.getInteger(context, "vertical");
+													return openScreen(client -> new PaddingTestGui(hori, vert)).run(context);
+												}))))
+
 		));
 	}
 

--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/PaddingTestGui.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/PaddingTestGui.java
@@ -1,0 +1,35 @@
+package io.github.cottonmc.test.client;
+
+import io.github.cottonmc.cotton.gui.client.LightweightGuiDescription;
+import io.github.cottonmc.cotton.gui.widget.WGridPanel;
+import io.github.cottonmc.cotton.gui.widget.WLabel;
+import io.github.cottonmc.cotton.gui.widget.data.HorizontalAlignment;
+import io.github.cottonmc.cotton.gui.widget.data.Insets;
+
+import io.github.cottonmc.cotton.gui.widget.data.VerticalAlignment;
+
+import net.minecraft.text.Text;
+
+public class PaddingTestGui extends LightweightGuiDescription {
+	public PaddingTestGui(int hori, int vert) {
+		var root = new WGridPanel();
+		root.setGaps(hori, vert);
+		setRootPanel(root);
+		root.setInsets(Insets.ROOT_PANEL);
+
+		addBox(root, 0, 0, 2, 1);
+		addBox(root, 0, 1, 1, 2);
+		addBox(root, 1, 1, 1, 1);
+		addBox(root, 1, 2, 1, 1);
+
+		root.validate(this);
+	}
+
+	void addBox(WGridPanel root, int x, int y, int w, int h) {
+		root.add(new TestClientGui.WColorBox(0xffff0000), x, y, w, h);
+		var l = new WLabel(Text.literal(w + "x" + h), 0xff00ffff);
+		l.setVerticalAlignment(VerticalAlignment.CENTER);
+		l.setHorizontalAlignment(HorizontalAlignment.CENTER);
+		root.add(l, x, y, w, h);
+	}
+}

--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/PaddingTestGui.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/PaddingTestGui.java
@@ -5,7 +5,6 @@ import io.github.cottonmc.cotton.gui.widget.WGridPanel;
 import io.github.cottonmc.cotton.gui.widget.WLabel;
 import io.github.cottonmc.cotton.gui.widget.data.HorizontalAlignment;
 import io.github.cottonmc.cotton.gui.widget.data.Insets;
-
 import io.github.cottonmc.cotton.gui.widget.data.VerticalAlignment;
 
 import net.minecraft.text.Text;

--- a/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
+++ b/GuiTest/src/main/java/io/github/cottonmc/test/client/TestClientGui.java
@@ -134,7 +134,16 @@ public class TestClientGui extends LightweightGuiDescription {
 	public static class WColorBox extends WWidget {
 		protected int color = 0xFF_FFFFFF;
 		public WColorBox() {}
-		
+
+		public WColorBox(int col) {
+			this.color = col;
+		}
+
+		@Override
+		public boolean canResize() {
+			return true;
+		}
+
 		public void setColor(int col) {
 			this.color = col;
 		}

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WGridPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WGridPanel.java
@@ -1,11 +1,15 @@
 package io.github.cottonmc.cotton.gui.widget;
 
+import io.github.cottonmc.cotton.gui.impl.VisualLogger;
 import io.github.cottonmc.cotton.gui.widget.data.Insets;
 
 /**
  * A panel that positions children in a grid.
  */
 public class WGridPanel extends WPanelWithInsets {
+
+	private static final VisualLogger LOGGER = new VisualLogger(WGridPanel.class);
+
 	/**
 	 * The grid size in pixels.
 	 * Defaults to 18, which is the size of one item slot.
@@ -13,16 +17,48 @@ public class WGridPanel extends WPanelWithInsets {
 	protected int grid = 18;
 
 	/**
+	 * The horizontal gap between two grid cells.
+	 */
+	protected int horizontalGap = 0;
+
+	/**
+	 * The vertical gap between two grid cells.
+	 */
+	protected int verticalGap = 0;
+
+	/**
 	 * Constructs a grid panel with the default grid size.
 	 */
-	public WGridPanel() {}
+	public WGridPanel() {
+	}
 
 	/**
 	 * Constructs a grid panel with a custom grid size.
 	 *
 	 * @param gridSize the grid size in pixels
 	 */
-	public WGridPanel(int gridSize) { this.grid = gridSize; }
+	public WGridPanel(int gridSize) {
+		this.grid = gridSize;
+	}
+
+
+	/**
+	 * Set the gaps between grid cells.
+	 *
+	 * <p><b>This method can only be called before any elements get added to this layout.</b></p>
+	 *
+	 * @param horizontalGap the horizontal gap between grid cells
+	 * @param verticalGap the vertical gap between grid cells
+	 */
+	public void setGaps(int horizontalGap, int verticalGap) {
+		if (!this.children.isEmpty()) {
+			LOGGER.warn("You can only change gaps before adding children to a WGridPanel");
+			return;
+		}
+		this.horizontalGap = horizontalGap;
+		this.verticalGap = verticalGap;
+	}
+
 
 	/**
 	 * Adds a widget to this panel.
@@ -35,14 +71,7 @@ public class WGridPanel extends WPanelWithInsets {
 	 * @param y the Y position in grid cells
 	 */
 	public void add(WWidget w, int x, int y) {
-		children.add(w);
-		w.parent = this;
-		w.setLocation(x * grid + insets.left(), y * grid + insets.top());
-		if (w.canResize()) {
-			w.setSize(grid, grid);
-		}
-		
-		expandToFit(w, insets);
+		add(w, x, y, 1, 1);
 	}
 
 	/**
@@ -57,11 +86,11 @@ public class WGridPanel extends WPanelWithInsets {
 	public void add(WWidget w, int x, int y, int width, int height) {
 		children.add(w);
 		w.parent = this;
-		w.setLocation(x * grid + insets.left(), y * grid + insets.top());
+		w.setLocation(x * (grid + horizontalGap) + insets.left(), y * (grid + verticalGap) + insets.top());
 		if (w.canResize()) {
-			w.setSize(width * grid, height * grid);
+			w.setSize((width-1) * (grid+horizontalGap) + grid, (height-1) * (grid+verticalGap) + grid);
 		}
-		
+
 		expandToFit(w, insets);
 	}
 

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WGridPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WGridPanel.java
@@ -7,7 +7,6 @@ import io.github.cottonmc.cotton.gui.widget.data.Insets;
  * A panel that positions children in a grid.
  */
 public class WGridPanel extends WPanelWithInsets {
-
 	private static final VisualLogger LOGGER = new VisualLogger(WGridPanel.class);
 
 	/**
@@ -29,17 +28,14 @@ public class WGridPanel extends WPanelWithInsets {
 	/**
 	 * Constructs a grid panel with the default grid size.
 	 */
-	public WGridPanel() {
-	}
+	public WGridPanel() {}
 
 	/**
 	 * Constructs a grid panel with a custom grid size.
 	 *
 	 * @param gridSize the grid size in pixels
 	 */
-	public WGridPanel(int gridSize) {
-		this.grid = gridSize;
-	}
+	public WGridPanel(int gridSize) { this.grid = gridSize; }
 
 
 	/**
@@ -50,13 +46,14 @@ public class WGridPanel extends WPanelWithInsets {
 	 * @param horizontalGap the horizontal gap between grid cells
 	 * @param verticalGap the vertical gap between grid cells
 	 */
-	public void setGaps(int horizontalGap, int verticalGap) {
+	public WGridPanel setGaps(int horizontalGap, int verticalGap) {
 		if (!this.children.isEmpty()) {
 			LOGGER.warn("You can only change gaps before adding children to a WGridPanel");
-			return;
+			return this;
 		}
 		this.horizontalGap = horizontalGap;
 		this.verticalGap = verticalGap;
+		return this;
 	}
 
 


### PR DESCRIPTION
I added those as static constructors, since managing regular constructor overloads with just a bunch of int arguments didn't work out.