### PR TITLE
Optimize WItem display position offset

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WItem.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WItem.java
@@ -65,7 +65,7 @@ public class WItem extends WWidget {
 		MinecraftClient mc = MinecraftClient.getInstance();
 		ItemRenderer renderer = mc.getItemRenderer();
 		renderer.zOffset = 100f;
-		renderer.renderInGui(items.get(current), x + getWidth() / 2 - 9, y + getHeight() / 2 - 9);
+		renderer.renderInGui(items.get(current), x + getWidth() / 2 - 8, y + getHeight() / 2 - 8);
 		renderer.zOffset = 0f;
 	}
 


### PR DESCRIPTION
# Unexpected `WItem` behavior
When I tried to display items in `WGridPanel` through `WItem`, they have an obvious position deviation, which is unexpected.
![WItemOld](https://user-images.githubusercontent.com/92242402/210125784-694788a8-5c63-4c34-bf3c-50038c0227cd.png)
As you can see, all the items displayed above have an one pixel offset by the both direction(x and y). That means the preset position of `WItem` in Grid may be undesirable. 
# Expected `WItem` behavior
![WItemNew](https://user-images.githubusercontent.com/92242402/210125965-95600945-6421-4da1-b2d6-b3b7f0b0d3f4.png)
This small change makes user displaying item in slot image more convenient.