### PR TITLE
Add scroll bar getters to `WScrollPanel`

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollPanel.java
@@ -51,6 +51,15 @@ public class WScrollPanel extends WClippedPanel {
 	}
 
 	/**
+	 * Returns this scroll panel's horizontal scroll bar.
+	 *
+	 * @return the horizontal scroll bar
+	 */
+	public WScrollBar getHorizontalScrollBar() {
+		return this.horizontalScrollBar;
+	}
+
+	/**
 	 * Returns whether this scroll panel has a horizontal scroll bar.
 	 *
 	 * @return true if there is a horizontal scroll bar,
@@ -68,6 +77,15 @@ public class WScrollPanel extends WClippedPanel {
 		}
 
 		return this;
+	}
+
+	/**
+	 * Returns this scroll panel's vertical scroll bar.
+	 *
+	 * @return the vertical scroll bar
+	 */
+	public WScrollBar getVerticalScrollBar() {
+		return this.verticalScrollBar;
 	}
 
 	/**

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WScrollPanel.java
@@ -9,6 +9,8 @@ import io.github.cottonmc.cotton.gui.GuiDescription;
 import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import io.github.cottonmc.cotton.gui.widget.data.InputResult;
 
+import java.util.Objects;
+
 /**
  * Similar to the JScrollPane in Swing, this widget represents a scrollable widget.
  *
@@ -60,6 +62,18 @@ public class WScrollPanel extends WClippedPanel {
 	}
 
 	/**
+	 * Sets this scroll panel's horizontal scroll bar.
+	 *
+	 * @param horizontalScrollBar the new horizontal scroll bar
+	 * @return this scroll panel
+	 * @throws NullPointerException if the horizontalScrollBar is null
+	 */
+	public WScrollPanel setHorizontalScrollBar(WScrollBar horizontalScrollBar) {
+		this.horizontalScrollBar = Objects.requireNonNull(horizontalScrollBar, "horizontalScrollBar");
+		return this;
+	}
+
+	/**
 	 * Returns whether this scroll panel has a horizontal scroll bar.
 	 *
 	 * @return true if there is a horizontal scroll bar,
@@ -86,6 +100,18 @@ public class WScrollPanel extends WClippedPanel {
 	 */
 	public WScrollBar getVerticalScrollBar() {
 		return this.verticalScrollBar;
+	}
+
+	/**
+	 * Sets this scroll panel's vertical scroll bar.
+	 *
+	 * @param verticalScrollBar the new vertical scroll bar
+	 * @return this scroll panel
+	 * @throws NullPointerException if the verticalScrollBar is null
+	 */
+	public WScrollPanel setVerticalScrollBar(WScrollBar verticalScrollBar) {
+		this.verticalScrollBar = Objects.requireNonNull(verticalScrollBar, "verticalScrollBar");
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
Adds getters for the vertical and horizontal scroll bars to `WScrollPanel`, which is useful for things like changing the scroll bar's speed.

~~Not sure if we want to have setters as well? let me know if that's the case and I can add that in.~~ Setters have been added.