### PR TITLE
Fix multiframe WSprite

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WSprite.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WSprite.java
@@ -202,7 +202,7 @@ public class WSprite extends WWidget {
 			if (currentFrameTime >= frameTime) {
 				currentFrame++;
 				//if we've hit the end of the animation, go back to the beginning
-				if (currentFrame >= frames.length - 1) {
+				if (currentFrame >= frames.length) {
 					currentFrame = 0;
 				}
 				currentFrameTime = 0;


### PR DESCRIPTION
Currently WSprite doesn't work correctly: it ignores the last frame because of a typo / duplicated check in .paint()