### PR TITLE
Fix client-sided field initialisers being used in common classes - 1.18.2 backport

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.13.3
 
 # Mod Properties
-	mod_version = 5.4.2
+	mod_version = 5.4.3
 	maven_group = io.github.cottonmc
 	archives_base_name = LibGui
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WItemSlot.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WItemSlot.java
@@ -70,7 +70,7 @@ public class WItemSlot extends WWidget {
 	private final List<ValidatedSlot> peers = new ArrayList<>();
 	@Nullable
 	@Environment(EnvType.CLIENT)
-	private BackgroundPainter backgroundPainter = null;
+	private BackgroundPainter backgroundPainter;
 	@Nullable
 	private Icon icon = null;
 	private Inventory inventory;

--- a/src/main/java/io/github/cottonmc/cotton/gui/widget/WPanel.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/widget/WPanel.java
@@ -26,7 +26,7 @@ public abstract class WPanel extends WWidget {
 	 */
 	protected final List<WWidget> children = new WidgetList(this, new ArrayList<>());
 	@Environment(EnvType.CLIENT)
-	private BackgroundPainter backgroundPainter = null;
+	private BackgroundPainter backgroundPainter;
 
 	/**
 	 * Removes the widget from this panel.


### PR DESCRIPTION
Fixes #231. Fabric Loader 0.15 fixes the treatment of client-only fields, so this code crashed before.